### PR TITLE
#2: migrate CI/CD to github

### DIFF
--- a/.github/workflows/ubuntu20.04-gcc11-x64.yml
+++ b/.github/workflows/ubuntu20.04-gcc11-x64.yml
@@ -20,10 +20,6 @@ jobs:
       image: nmm0/distbvh-ubuntu20.04-gcc11-x64:ci-images
     steps:
       - uses: actions/checkout@v4
-      - name: Activate Spack Environment
-        run: |
-          . /opt/spack/share/spack/setup-env.sh
-          spack env activate -d /opt/spack-env
       - name: Configure
         run: cmake --preset ci-gcc11-x64
       - name: Build
@@ -44,10 +40,6 @@ jobs:
         with:
           name: build-directory
           path: /opt/builds/bvh
-      - name: Activate Spack Environment
-        run: |
-          . /opt/spack/share/spack/setup-env.sh
-          spack env activate -d /opt/spack-env
       - name: Run CTest
         run: ctest --preset ci-gcc11-x64
   integration_tests:
@@ -64,10 +56,6 @@ jobs:
         with:
           name: build-directory
           path: /opt/builds/bvh
-      - name: Activate Spack Environment
-        run: |
-          . /opt/spack/share/spack/setup-env.sh
-          spack env activate -d /opt/spack-env
       - name: Build NimbleSM
         run: bash ci/nimble_build_integration.sh
       - name: Sphere/plate contact test

--- a/.github/workflows/ubuntu20.04-gcc11-x64.yml
+++ b/.github/workflows/ubuntu20.04-gcc11-x64.yml
@@ -20,6 +20,10 @@ jobs:
       image: nmm0/distbvh-ubuntu20.04-gcc11-x64:ci-images
     steps:
       - uses: actions/checkout@v4
+      - name: Activate Spack Environment
+        run: |
+          . /opt/spack/share/spack/setup-env.sh
+          spack env activate -d /opt/spack-env
       - name: Configure
         run: cmake --preset ci-gcc11-x64
       - name: Build
@@ -40,6 +44,10 @@ jobs:
         with:
           name: build-directory
           path: /opt/builds/bvh
+      - name: Activate Spack Environment
+        run: |
+          . /opt/spack/share/spack/setup-env.sh
+          spack env activate -d /opt/spack-env
       - name: Run CTest
         run: ctest --preset ci-gcc11-x64
   integration_tests:
@@ -56,6 +64,10 @@ jobs:
         with:
           name: build-directory
           path: /opt/builds/bvh
+      - name: Activate Spack Environment
+        run: |
+          . /opt/spack/share/spack/setup-env.sh
+          spack env activate -d /opt/spack-env
       - name: Build NimbleSM
         run: bash ci/nimble_build_integration.sh
       - name: Sphere/plate contact test

--- a/.github/workflows/ubuntu20.04-gcc11-x64.yml
+++ b/.github/workflows/ubuntu20.04-gcc11-x64.yml
@@ -40,6 +40,8 @@ jobs:
         with:
           name: build-directory
           path: /opt/builds/bvh
+      - name: Set executable permissions
+        run: chmod +x /opt/builds/bvh/tests/BVHTests
       - name: Run CTest
         run: ctest --preset ci-gcc11-x64
   integration_tests:

--- a/.github/workflows/ubuntu20.04-gcc11-x64.yml
+++ b/.github/workflows/ubuntu20.04-gcc11-x64.yml
@@ -1,0 +1,69 @@
+name: Build and Test Ubuntu 20.04 gcc 11 x64
+
+# Trigger the workflow on push or pull request
+on:
+  push:
+    branches:
+      - master
+      - develop
+  pull_request:
+    branches:
+      - develop-refactor
+      - master
+      - develop
+
+  workflow_dispatch:
+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Build distBVH
+    container:
+      image: nmm0/nimblesm-base-env:main
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure
+        run: cmake --preset ci-gcc11-x64
+      - name: Build
+        run: cmake --build --preset ci-gcc11-x64 --parallel $(nproc)
+      - uses: actions/upload-artifact@v3
+        with:
+          name: build-directory
+          path: /opt/builds/bvh
+  unit_tests:
+    runs-on: ubuntu-latest
+    name: Unit Tests
+    container:
+      image: nmm0/nimblesm-base-env:main
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v3
+        with:
+          name: build-directory
+          path: /opt/builds/bvh
+      - name: Run CTest
+        run: ctest --preset ci-gcc11-x64
+  integration_tests:
+    runs-on: ubuntu-latest
+    name: Integration Tests
+    container:
+      image: nmm0/nimblesm-base-env:main
+    needs: build
+    env:
+      TRACE_OUTPUT_DIR: /opt/runs/NimbleSM/trace
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v3
+        with:
+          name: build-directory
+          path: /opt/builds/bvh
+      - name: Build NimbleSM
+        run: bash ci/nimble_build_integration.sh
+      - name: Sphere/plate contact test
+        run: bash ci/nimble_test_integration.sh sphere_plate_contact
+      - uses: actions/upload-artifact@v3
+        with:
+          name: traces
+          path: ${{ env.TRACE_OUTPUT_DIR }}

--- a/.github/workflows/ubuntu20.04-gcc11-x64.yml
+++ b/.github/workflows/ubuntu20.04-gcc11-x64.yml
@@ -4,13 +4,10 @@ name: Build and Test Ubuntu 20.04 gcc 11 x64
 on:
   push:
     branches:
-      - master
-      - develop
+      - main
   pull_request:
     branches:
-      - develop-refactor
-      - master
-      - develop
+      - main
 
   workflow_dispatch:
 

--- a/.github/workflows/ubuntu20.04-gcc11-x64.yml
+++ b/.github/workflows/ubuntu20.04-gcc11-x64.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Build distBVH
     container:
-      image: nmm0/nimblesm-base-env:main
+      image: nmm0/distbvh-ubuntu20.04-gcc11-x64:ci-images
     steps:
       - uses: actions/checkout@v4
       - name: Configure
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Unit Tests
     container:
-      image: nmm0/nimblesm-base-env:main
+      image: nmm0/distbvh-ubuntu20.04-gcc11-x64:ci-images
     needs: build
     steps:
       - uses: actions/checkout@v4
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Integration Tests
     container:
-      image: nmm0/nimblesm-base-env:main
+      image: nmm0/distbvh-ubuntu20.04-gcc11-x64:ci-images
     needs: build
     env:
       TRACE_OUTPUT_DIR: /opt/runs/NimbleSM/trace

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -35,6 +35,9 @@
       "execution": {
         "stopOnFailure": false,
         "noTestsAction": "error"
+      },
+      "environment": {
+        "PATH": "/opt/view/bin:$penv{PATH}"
       }
     }
   ]

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -13,6 +13,7 @@
       "cacheVariables": {
         "CMAKE_C_COMPILER": "gcc-11",
         "CMAKE_CXX_COMPILER": "g++-11",
+        "CMAKE_PREFIX_PATH": "/opt/view",
         "CMAKE_BUILD_TYPE": "Release",
         "BVH_DISABLE_TESTS": "OFF"
       }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,40 @@
+{
+  "version": 4,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 21,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "ci-gcc11-x64",
+      "generator": "Unix Makefiles",
+      "binaryDir": "/opt/builds/bvh",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "gcc-11",
+        "CMAKE_CXX_COMPILER": "g++-11",
+        "CMAKE_BUILD_TYPE": "Release",
+        "BVH_DISABLE_TESTS": "OFF"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "ci-gcc11-x64",
+      "configurePreset": "ci-gcc11-x64"
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "ci-gcc11-x64",
+      "configurePreset": "ci-gcc11-x64",
+      "output": {
+        "outputOnFailure": true
+      },
+      "execution": {
+        "stopOnFailure": false,
+        "noTestsAction": "error"
+      }
+    }
+  ]
+}

--- a/ci/nimble_build_integration.sh
+++ b/ci/nimble_build_integration.sh
@@ -10,6 +10,7 @@ mkdir -p /opt/builds/NimbleSM
 pushd /opt/builds/NimbleSM
 cmake -DCMAKE_C_COMPILER="gcc-11" \
   -DCMAKE_CXX_COMPILER="g++-11" \
+  -DCMAKE_PREFIX_PATH="/opt/view" \
   -DNimbleSM_ENABLE_KOKKOS="ON" \
   -DNimbleSM_ENABLE_BVH="ON" \
   -DNimbleSM_ENABLE_MPI="ON" \

--- a/ci/nimble_build_integration.sh
+++ b/ci/nimble_build_integration.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -e
+mkdir -p /opt/src
+
+pushd /opt/src
+git clone https://github.com/NimbleSM/NimbleSM.git
+mkdir -p /opt/builds/NimbleSM
+
+pushd /opt/builds/NimbleSM
+cmake -DCMAKE_C_COMPILER="gcc-11" \
+  -DCMAKE_CXX_COMPILER="g++-11" \
+  -DNimbleSM_ENABLE_KOKKOS="ON" \
+  -DNimbleSM_ENABLE_BVH="ON" \
+  -DNimbleSM_ENABLE_MPI="ON" \
+  -Dbvh_ROOT="/opt/builds/bvh" \
+  /opt/src/NimbleSM
+cmake --build . -j $(nproc)
+
+popd  # /opt/builds/NimbleSM
+popd  # /opt/src

--- a/ci/nimble_test_integration.sh
+++ b/ci/nimble_test_integration.sh
@@ -7,6 +7,8 @@ if [ $# -lt 1 ]; then
   exit 1
 fi
 
+export PATH=/opt/view/bin:$PATH
+
 test_name=$1
 trace_out_dir=$TRACE_OUTPUT_DIR/$test_name
 

--- a/ci/nimble_test_integration.sh
+++ b/ci/nimble_test_integration.sh
@@ -12,6 +12,9 @@ export PATH=/opt/view/bin:$PATH
 test_name=$1
 trace_out_dir=$TRACE_OUTPUT_DIR/$test_name
 
+# Make parent directory for trace
+mkdir -p $TRACE_OUTPUT_DIR
+
 pushd /opt/builds/NimbleSM/test/contact/$test_name
 mpirun -np 2 /opt/builds/NimbleSM/src/NimbleSM \
   $test_name.in \

--- a/ci/nimble_test_integration.sh
+++ b/ci/nimble_test_integration.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+
+if [ $# -lt 1 ]; then
+  echo "Required arguments: <test_name>"
+  exit 1
+fi
+
+test_name=$1
+trace_out_dir=$TRACE_OUTPUT_DIR/$test_name
+
+pushd /opt/builds/NimbleSM/test/contact/$test_name
+mpirun -np 2 /opt/builds/NimbleSM/src/NimbleSM \
+  $test_name.in \
+  --use_vt \
+  --vt_trace --vt_trace_dir=$trace_out_dir \
+  --vt_lb --vt_lb_name=HierarchicalLB --vt_lb_interval=10 --vt_lb_keep_last_elm
+
+popd  # /opt/builds/NimbleSM/test/contact/$test_name


### PR DESCRIPTION
Closes #2

This will use CI images built in the branch https://github.com/sandialabs/distBVH/tree/ci-images (It's an orphan branch so should never be merged)

The image is here: https://hub.docker.com/layers/nmm0/distbvh-ubuntu20.04-gcc11-x64/ci-images/images/sha256-26e28d5ea7a162adfe4e916ca49b99ec977cbf2d68093041e2f9e1ea54e1ef43?context=explore