### PR TITLE
#15: add custom Cuda image to speed up testing

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -1,4 +1,4 @@
-name: Build ubuntu20-gcc11-x64 Image
+name: Build Docker Images
 
 on:
   push:

--- a/.github/workflows/ubuntu20.04-gcc11-x64.yml
+++ b/.github/workflows/ubuntu20.04-gcc11-x64.yml
@@ -13,9 +13,14 @@ jobs:
   build_and_push:
     name: Build and Push Image
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image:
+          - ubuntu20.04-gcc11-x64
+          - cuda11.4.3-gcc9.4-x64
     env:
-      IMAGE_TAG: nmm0/distbvh-ubuntu20.04-gcc11-x64:ci-images
-      CACHE_TAG: nmm0/distbvh-ubuntu20.04-gcc11-x64:buildcache
+      IMAGE_TAG: nmm0/distbvh-${{ matrix.image }}:ci-images
+      CACHE_TAG: nmm0/distbvh-${{ matrix.image }}:buildcache
     steps:
       - uses: actions/checkout@v4
 
@@ -36,7 +41,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
-          file: ubuntu20.04-gcc11-x64.dockerfile
+          file: ${{ matrix.image }}.dockerfile
           cache-from: type=registry,ref=docker.io/${{ env.CACHE_TAG }}
           cache-to: type=registry,ref=docker.io/${{ env.CACHE_TAG }},mode=max
           push: ${{ (github.event_name == 'push' || github.ref == 'refs/heads/ci-images') && 'true' || 'false' }}

--- a/cuda11.4.3-gcc9.4-x64.dockerfile
+++ b/cuda11.4.3-gcc9.4-x64.dockerfile
@@ -42,11 +42,13 @@ RUN cmake -B /vt/builddir -S /vt \
         -Dvt_build_tests=OFF \
         -Dvt_build_tools=OFF \
         -Dvt_trace_enabled=ON \
-    && cmake --build /vt/builddir --target install
+    && cmake --build /vt/builddir --target install -j 2 \
+    && rm -rf /vt/builddir
 
 RUN cmake -B /kokkos/builddir -S /kokkos \
         -DCMAKE_CXX_COMPILER=/kokkos/bin/nvcc_wrapper \
         -DKokkos_ENABLE_CUDA=ON \
         -DKokkos_ENABLE_CUDA_LAMBDA=ON \
         -DKokkos_ARCH_PASCAL61=ON \
-    && cmake --build /kokkos/builddir --target install
+    && cmake --build /kokkos/builddir --target install -j 2 \
+    && rm -rf /kokkos/builddir

--- a/cuda11.4.3-gcc9.4-x64.dockerfile
+++ b/cuda11.4.3-gcc9.4-x64.dockerfile
@@ -1,0 +1,52 @@
+FROM nvidia/cuda:11.4.3-devel-ubuntu20.04
+
+RUN apt update \
+    && DEBIAN_FRONTEND="noninteractive" apt install -y \
+        bzip2 \
+        git \
+        gpg \
+        gpgconf \
+        libmpich-dev \
+        libncurses5-dev \
+        libsigsegv-dev \
+        libsigsegv2 \
+        m4 \
+        perl \
+        pkg-config \
+        python3 \
+        python3-distutils \
+        python3-pip \
+        software-properties-common \
+        wget \
+        xz-utils \
+        zip \
+        zlib1g \
+        zlib1g-dev \
+    && wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null \
+    && echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ focal main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null \
+    && apt update \
+    && DEBIAN_FRONTEND="noninteractive" apt install -y \
+        cmake-data=3.26.4-0kitware1ubuntu20.04.1 \
+        cmake=3.26.4-0kitware1ubuntu20.04.1 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN git clone --branch develop --depth 1 https://github.com/kokkos/kokkos.git \
+    && git clone --branch develop --depth 1 https://github.com/DARMA-tasking/vt.git \
+    && git clone --branch develop --depth 1 https://github.com/DARMA-tasking/magistrate.git vt/lib/checkpoint \
+    && git config --global --add safe.directory /kokkos \
+    && git config --global --add safe.directory /vt
+
+RUN cmake -B /vt/builddir -S /vt \
+        -DCMAKE_CXX_COMPILER=/kokkos/bin/nvcc_wrapper \
+        -Dvt_build_examples=OFF \
+        -Dvt_build_tests=OFF \
+        -Dvt_build_tools=OFF \
+        -Dvt_trace_enabled=ON \
+    && cmake --build /vt/builddir --target install
+
+RUN cmake -B /kokkos/builddir -S /kokkos \
+        -DCMAKE_CXX_COMPILER=/kokkos/bin/nvcc_wrapper \
+        -DKokkos_ENABLE_CUDA=ON \
+        -DKokkos_ENABLE_CUDA_LAMBDA=ON \
+        -DKokkos_ARCH_PASCAL61=ON \
+    && cmake --build /kokkos/builddir --target install


### PR DESCRIPTION
fixes #15 
Based on `nvidia/cuda:11.4.3-devel-ubuntu20.04` - this can be adjusted if needed.

TODO: 
- [x] ~cleanup after builds to reduce image size~
- [x] ~fix the name (line 1)~