### PR TITLE
Add sphere collision examples

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -31,8 +31,8 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ]]
 
-macro(add_example name sources)
-  add_executable(${name} ${sources})
+macro(add_example name)
+  add_executable(${name} ${ARGN})
   target_link_libraries(${name} bvh::bvh)
   target_compile_options(${name} PRIVATE
                          $<$<CONFIG:Debug>:-g3 -ggdb -O0>)

--- a/examples/spheres/CMakeLists.txt
+++ b/examples/spheres/CMakeLists.txt
@@ -38,3 +38,11 @@ add_example(granular_object_test
   granular_object.cpp
   granular_object_test.cpp
 )
+
+add_example(collide_two_blocks
+  sphere.hpp
+  collision_sphere.hpp
+  granular_object.hpp
+  granular_object.cpp
+  collide_two_blocks.cpp
+)

--- a/examples/spheres/CMakeLists.txt
+++ b/examples/spheres/CMakeLists.txt
@@ -31,22 +31,10 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ]]
 
-macro(add_example name)
-  add_executable(${name} ${ARGN})
-  target_link_libraries(${name} bvh::bvh)
-  target_compile_options(${name} PRIVATE
-                         $<$<CONFIG:Debug>:-g3 -ggdb -O0>)
-
-  target_compile_options(${name} PRIVATE
-                         $<$<CONFIG:Release>:-O3 -ffast-math>)
-  target_compile_options(${name} PRIVATE -Werror)
-endmacro()
-
-# Visualization examples
-
-if (VTK_FOUND)
-  add_example(vis_kdop vis_kdop.cpp)
-  add_example(vis_bvh vis_bvh.cpp)
-endif()
-
-add_subdirectory(spheres)
+add_example(granular_object_test
+  sphere.hpp
+  collision_sphere.hpp
+  granular_object.hpp
+  granular_object.cpp
+  granular_object_test.cpp
+)

--- a/examples/spheres/collide_two_blocks.cpp
+++ b/examples/spheres/collide_two_blocks.cpp
@@ -1,0 +1,331 @@
+/*
+ * distBVH 1.0
+ *
+ * Copyright 2023 National Technology & Engineering Solutions of Sandia, LLC
+ * (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+ * Government retains certain rights in this software.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS”
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <vt/vt.h>
+
+#include <Kokkos_Core.hpp>
+#include <bvh/collision_object.hpp>
+#include <bvh/collision_world.hpp>
+#include <bvh/math/vec.hpp>
+#include <iostream>
+#include <utility>
+#include <vector>
+
+#include "collision_sphere.hpp"
+#include "granular_object.hpp"
+
+using narrowphase_result = std::pair<int, int>;
+
+struct Config {
+  Config(int argc, char **argv);
+
+  std::string
+  help_message() {
+    // clang-format off
+    return std::string(
+        "collision between two block objects consisting of spheres\n"
+        "\n"
+        "setup:\n"
+        "  - both objects consist of [np * nx, ny, nz] number of spheres placed in a\n"
+        "    primitive cubic packing arrangement\n"
+        "  - the first object is fixed; the plane through the centers of its top-level\n"
+        "    spheres coincides with the x-y coordinate plane\n"
+        "  - the second object is free; its initial position coincides with the position\n"
+        "    of the second object shifted upwards\n"
+        "  - the separation of the plane through the centers of the top-level spheres of\n"
+        "    the first object, and the plane through the coenters of the bottom level\n"
+        "    spheres of the second is user specified\n"
+        "  - both objects are split among MPI ranks along the x direction; splitting is\n"
+        "    even for the second object"
+        "  - the x-directional splitting of the first object among MPI ranks could be\n"
+        "    uneven based on a parameter dnx; essentially, if np >= 2,\n"
+        "    - rank 0 has (nx - dnx) along x direction\n"
+        "    - rank k has (nx - (-1)^k * 2 * dnx) along x direction for 1 <= k <= np - 2\n"
+        "    - rank (np - 1) has (nx - (-1)^(np - 1) dnx) spheres along x direction\n"
+        "  - the second object falls under gravity; after collision with the first\n"
+        "    object, its velocity is reversed in the z direction\n"
+        "  - time integration is performed using forward Euler scheme with fixed step\n"
+        "    size h for a specified number k of step\n"
+        "\n"
+        "usage:"
+        "  ") + std::string(program_name_) + std::string(" \\\n"
+        "      [vt-options] \\\n"
+        "      [kokkos-options] \\\n"
+        "      -- \\\n"
+        "      [--num_sphere_x nx  (default: 5)   ] \\\n"
+        "      [--num_sphere_y ny  (default: 5)   ] \\\n"
+        "      [--num_sphere_z nz  (default: 5)   ] \\\n"
+        "      [--imbalance_x  dnx (default: 2)   ] \\\n"
+        "      [--step_size    h   (default: 0.01)] \\\n"
+        "      [--num_step     k   (default: 100) ] \\\n"
+        "\n");
+    // clang-format on
+  }
+
+  const std::string program_name_;
+
+  bool emit_help_message = false;
+
+  int num_sphere_x = 5;
+  int num_sphere_y = 5;
+  int num_sphere_z = 5;
+  int imbalance_x = 2;
+  double object_2_height = 2.0;
+  double step_size = 1.0e-02;
+  int num_step = 100;
+};
+
+Config::Config(int argc, char **argv) : program_name_(argv[0]) {
+  for (int i = 1; i < argc; ++i) {
+    std::string arg = argv[i];
+    if (arg == "--help" || arg == "-h") {
+      emit_help_message = true;
+    } else if (arg == "--num_sphere_x") {
+      num_sphere_x = std::stoi(argv[++i]);
+
+      if (num_sphere_x < 1) {
+        throw std::invalid_argument(
+            "number of spheres along x direction must be positive");
+      }
+    } else if (arg == "--num_sphere_y") {
+      num_sphere_y = std::stoi(argv[++i]);
+
+      if (num_sphere_y < 1) {
+        throw std::invalid_argument(
+            "number of spheres along y direction must be positive");
+      }
+    } else if (arg == "--num_sphere_z") {
+      num_sphere_z = std::stoi(argv[++i]);
+
+      if (num_sphere_z < 1) {
+        throw std::invalid_argument(
+            "number of spheres along z direction must be positive");
+      }
+    } else if (arg == "--imbalance_x") {
+      imbalance_x = std::stoi(argv[++i]);
+
+      if (imbalance_x < 0) {
+        throw std::invalid_argument(
+            "imbalance along x direction must be non-negative");
+      } else if (2 * imbalance_x > num_sphere_x) {
+        throw std::invalid_argument(
+            "imbalance must be no larger than half the number of spheres along "
+            "x direction");
+      }
+    } else if (arg == "--object_2_height") {
+      object_2_height = std::stof(argv[++i]);
+
+      if (object_2_height < 1.0) {
+        throw std::invalid_argument("height of object 2 must be at least 1.0");
+      }
+    } else if (arg == "--step_size") {
+      step_size = std::stof(argv[++i]);
+
+      if (step_size <= 0.0) {
+        throw std::invalid_argument(" step size must be positive");
+      }
+    } else if (arg == "--num_step") {
+      num_step = std::stoi(argv[++i]);
+
+      if (num_step < 1) {
+        throw std::invalid_argument("number of steps must be positive");
+      }
+    } else {
+      std::cerr << "ignoring unknown option \"" << arg << "\"\n";
+    }
+  }
+
+  std::cerr << std::flush;
+}
+
+void
+Main(const Config &config) {
+  const int num_sphere_x = config.num_sphere_x;
+  const int num_sphere_y = config.num_sphere_y;
+  const int num_sphere_z = config.num_sphere_z;
+  const double object_2_height = config.object_2_height;
+  const double step_size = config.step_size;
+  const int num_step = config.num_step;
+
+  const int imbalance_x = config.imbalance_x;
+
+  const auto n_nodes = vt::theContext()->getNumNodes();
+  const auto node_id = vt::theContext()->getNode();
+
+  int num_sphere_x_object_1 = num_sphere_x;
+  int gid_offset_x_object_1 = node_id * num_sphere_x;
+
+  if (n_nodes > 1) {
+    if (node_id % 2 == 0) {
+      num_sphere_x_object_1 -= (node_id == 0 || node_id == n_nodes - 1)
+                                   ? imbalance_x
+                                   : 2 * imbalance_x;
+      gid_offset_x_object_1 += node_id > 0 ? imbalance_x : 0;
+    } else {
+      num_sphere_x_object_1 += (node_id == 0 || node_id == n_nodes - 1)
+                                   ? imbalance_x
+                                   : 2 * imbalance_x;
+      gid_offset_x_object_1 -= node_id > 0 ? imbalance_x : 0;
+    }
+  }
+
+  const int num_sphere_x_object_2 = num_sphere_x;
+  const int gid_offset_x_object_2 = node_id * num_sphere_x;
+
+  GranularObject object_1(
+      "sheet_1",
+      num_sphere_x_object_1,
+      num_sphere_y,
+      num_sphere_z,
+      gid_offset_x_object_1 * num_sphere_y * num_sphere_z,
+      bvh::m::vec3d(
+          double(gid_offset_x_object_1), 0.0, 1.0 - double(num_sphere_z)));
+  GranularObject object_2(
+      "sheet_2",
+      num_sphere_x_object_2,
+      num_sphere_y,
+      num_sphere_z,
+      (gid_offset_x_object_2 + n_nodes * num_sphere_x) * num_sphere_y *
+          num_sphere_z,
+      bvh::m::vec3d(double(gid_offset_x_object_2), 0.0, object_2_height));
+
+  bvh::collision_world world(2);
+  bvh::collision_object &collision_object_1 = world.create_collision_object();
+  bvh::collision_object &collision_object_2 = world.create_collision_object();
+
+  std::ofstream os;
+  if (node_id == 0) {
+    os.open("collide_two_blocks.csv");
+    os << "time,obj_2_pos_z,obj_2_vel_z,num_collision\n";
+  }
+
+  vt::runInEpochCollective("time_iterations", [&]() {
+    for (int step_index = 0; step_index < num_step; ++step_index) {
+      world.start_iteration();
+
+      collision_object_1.set_entity_data(object_1.collision_spheres(),
+                                         bvh::split_algorithm::geom_axis);
+      collision_object_1.init_broadphase();
+
+      collision_object_2.set_entity_data(object_2.collision_spheres(),
+                                         bvh::split_algorithm::geom_axis);
+      collision_object_2.init_broadphase();
+
+      world.set_narrowphase_functor<CollisionSphere>(
+          [node_id](const bvh::broadphase_collision<CollisionSphere> &set_1,
+                    const bvh::broadphase_collision<CollisionSphere> &set_2) {
+            auto result = bvh::narrowphase_result_pair();
+
+            result.a = bvh::narrowphase_result(sizeof(narrowphase_result));
+            result.b = bvh::narrowphase_result(sizeof(narrowphase_result));
+
+            auto &result_a = static_cast<
+                bvh::typed_narrowphase_result<narrowphase_result> &>(result.a);
+            auto &result_b = static_cast<
+                bvh::typed_narrowphase_result<narrowphase_result> &>(result.b);
+
+            for (auto &&sphere_1 : set_1.elements) {
+              for (auto &&sphere_2 : set_2.elements) {
+                if (sphere_1.is_colliding_with(sphere_2)) {
+                  result_a.emplace_back(std::make_pair(sphere_1.global_id(),
+                                                       sphere_2.global_id()));
+                }
+              }
+            }
+
+            return result;
+          });
+
+      collision_object_1.broadphase(collision_object_2);
+
+      std::vector<narrowphase_result> results;
+      collision_object_1.for_each_result<narrowphase_result>(
+          [node_id, &results](const narrowphase_result &res) {
+            results.emplace_back(res);
+          });
+
+      world.finish_iteration();
+
+      if (results.size() != 0) {
+        const auto velocity = object_2.velocity();
+        object_2.set_velocity(
+            bvh::m::vec3d(velocity.x(), velocity.y(), -velocity.z()));
+      }
+
+      object_2.step(step_size);
+
+      if (node_id == 0) {
+        os << fmt::format("{:.3e},{:.3e},{:.3e},{}\n",
+                          (step_index + 1) * step_size,
+                          object_2.position().z(),
+                          object_2.velocity().z(),
+                          results.size());
+      }
+    }
+  });
+}
+
+int
+main(int argc, char **argv) {
+  int return_code = 0;
+  std::string error_message = "";
+
+  vt::initialize(argc, argv);
+  Kokkos::initialize(argc, argv);
+
+  try {
+    Config config(argc, argv);
+    if (config.emit_help_message) {
+      std::cout << config.help_message() << std::endl;
+    } else {
+      Main(config);
+    }
+    return_code = 0;
+  } catch (std::exception &e) {
+    error_message = e.what();
+    return_code = 1;
+  } catch (...) {
+    error_message = "encountered unknown exception";
+    return_code = 1;
+  }
+
+  Kokkos::finalize();
+  vt::finalize();
+
+  if (return_code) {
+    std::cerr << error_message << std::endl;
+  }
+
+  return return_code;
+}

--- a/examples/spheres/collision_sphere.hpp
+++ b/examples/spheres/collision_sphere.hpp
@@ -56,7 +56,8 @@ public:
       : global_id_(s.global_id()),
         radius_(s.radius()),
         centroid_(s.position()),
-        bounds_(bvh::bphase_kdop::from_sphere(s.position(), s.radius())) {}
+        bounds_(bvh::bphase_kdop::from_sphere(s.position(),
+                                              (1.0 + buffer_) * s.radius())) {}
 
   KOKKOS_INLINE_FUNCTION CollisionSphere &
   operator=(const CollisionSphere &) = default;
@@ -69,7 +70,8 @@ public:
     global_id_ = s.global_id();
     radius_ = s.radius();
     centroid_ = s.position();
-    bounds_ = bvh::bphase_kdop::from_sphere(s.position(), s.radius());
+    bounds_ = bvh::bphase_kdop::from_sphere(s.position(),
+                                            (1.0 + buffer_) * s.radius());
     return *this;
   }
 
@@ -91,7 +93,7 @@ public:
   bool
   is_colliding_with(const CollisionSphere &other) const {
     return bvh::m::length(centroid_ - other.centroid_) <=
-           radius_ + other.radius_;
+           (1 + buffer_) * (radius_ + other.radius_);
   }
 
 private:
@@ -99,6 +101,9 @@ private:
   double radius_;
   bvh::m::vec3d centroid_;
   bvh::bphase_kdop bounds_;
+
+private:
+  static constexpr double buffer_ = 0.01;
 };
 
 #endif

--- a/examples/spheres/collision_sphere.hpp
+++ b/examples/spheres/collision_sphere.hpp
@@ -1,0 +1,104 @@
+/*
+ * distBVH 1.0
+ *
+ * Copyright 2023 National Technology & Engineering Solutions of Sandia, LLC
+ * (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+ * Government retains certain rights in this software.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS”
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef COLLISION_SPHERE_HPP
+#define COLLISION_SPHERE_HPP
+
+#include <bvh/math/vec.hpp>
+#include <bvh/types.hpp>
+#include <cstddef>
+#include <type_traits>
+
+#include "sphere.hpp"
+
+class CollisionSphere {
+public:
+  KOKKOS_INLINE_FUNCTION CollisionSphere() = default;
+
+  KOKKOS_INLINE_FUNCTION ~CollisionSphere() = default;
+
+  CollisionSphere(const CollisionSphere &) = default;
+
+  CollisionSphere(CollisionSphere &&) noexcept = default;
+
+  CollisionSphere(const Sphere &s)
+      : global_id_(s.global_id()),
+        radius_(s.radius()),
+        centroid_(s.position()),
+        bounds_(bvh::bphase_kdop::from_sphere(s.position(), s.radius())) {}
+
+  KOKKOS_INLINE_FUNCTION CollisionSphere &
+  operator=(const CollisionSphere &) = default;
+
+  KOKKOS_INLINE_FUNCTION CollisionSphere &
+  operator=(CollisionSphere &&) noexcept = default;
+
+  KOKKOS_INLINE_FUNCTION CollisionSphere &
+  operator=(const Sphere &s) {
+    global_id_ = s.global_id();
+    radius_ = s.radius();
+    centroid_ = s.position();
+    bounds_ = bvh::bphase_kdop::from_sphere(s.position(), s.radius());
+    return *this;
+  }
+
+  std::size_t
+  global_id() const {
+    return std::size_t(global_id_);
+  }
+
+  bvh::m::vec3d
+  centroid() const {
+    return centroid_;
+  }
+
+  const bvh::bphase_kdop &
+  kdop() const {
+    return bounds_;
+  }
+
+  bool
+  is_colliding_with(const CollisionSphere &other) const {
+    return bvh::m::length(centroid_ - other.centroid_) <=
+           radius_ + other.radius_;
+  }
+
+private:
+  int global_id_;
+  double radius_;
+  bvh::m::vec3d centroid_;
+  bvh::bphase_kdop bounds_;
+};
+
+#endif

--- a/examples/spheres/granular_object.cpp
+++ b/examples/spheres/granular_object.cpp
@@ -1,0 +1,160 @@
+/*
+ * distBVH 1.0
+ *
+ * Copyright 2023 National Technology & Engineering Solutions of Sandia, LLC
+ * (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+ * Government retains certain rights in this software.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS”
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "granular_object.hpp"
+
+#include <Kokkos_Core.hpp>
+
+void
+GranularObject::generate_spheres(const int &global_id_offset,
+                                 const bvh::m::vec3d &shift) {
+  const std::string view_name = object_name_ + "_spheres";
+  const int num_sphere = nx_ * ny_ * nz_;
+
+  spheres_ = bvh::view<Sphere *>(view_name, num_sphere);
+
+  const double radius = 0.5;
+
+  Kokkos::parallel_for(
+      Kokkos::MDRangePolicy<Kokkos::Rank<3> >{{0, 0, 0}, {nx_, ny_, nz_}},
+      KOKKOS_LAMBDA(int ix, int iy, int iz) {
+        const auto &local_id = get_local_id(ix, iy, iz);
+        const auto &global_id = global_id_offset + local_id;
+        const auto &position =
+            bvh::m::vec3d(double(ix), double(iy), double(iz)) + shift;
+
+        auto &sphere = spheres_(local_id);
+
+        sphere.set_global_id(global_id);
+        sphere.set_radius(radius);
+        sphere.set_position(position);
+      });
+}
+
+void
+GranularObject::compute_collision_sphere_indices() {
+  const std::string view_name = object_name_ + "_collision_sphere_indices";
+  int num_collision_sphere = 0;
+  bool all_spheres_on_boundary = false;
+
+  if (nx_ <= 2 || ny_ <= 2 || nz_ <= 2) {
+    num_collision_sphere = nx_ * ny_ * nz_;
+    all_spheres_on_boundary = true;
+  } else {
+    num_collision_sphere =
+        2 * (nx_ * ny_ + ny_ * nz_ + nz_ * nx_) - 4 * (nx_ + ny_ + nz_) + 8;
+    all_spheres_on_boundary = false;
+  }
+
+  collision_sphere_indices_ = bvh::view<int *>(view_name, num_collision_sphere);
+
+  if (all_spheres_on_boundary) {
+    Kokkos::parallel_for(
+        Kokkos::RangePolicy<int>(0, num_collision_sphere),
+        KOKKOS_LAMBDA(int i) { collision_sphere_indices_(i) = i; });
+
+    return;
+  }
+
+  Kokkos::parallel_for(
+      Kokkos::MDRangePolicy<Kokkos::Rank<2> >{{0, 0}, {nx_, ny_}},
+      KOKKOS_LAMBDA(int ix, int iy) {
+        int local_id = get_local_id(ix, iy, 0);
+        int collision_local_id = ix + iy * nx_;  // bottom layer
+        collision_sphere_indices_(collision_local_id) = local_id;
+
+        local_id = get_local_id(ix, iy, nz_ - 1);
+        collision_local_id =
+            nx_ * ny_ + (nz_ - 2) * (2 * nx_ + 2 * (ny_ - 2)) + ix + iy * nx_;
+        collision_sphere_indices_(collision_local_id) = local_id;
+      });
+
+  Kokkos::parallel_for(
+      Kokkos::MDRangePolicy<Kokkos::Rank<2> >{{0, 1}, {nx_, nz_ - 1}},
+      KOKKOS_LAMBDA(int ix, int iz) {
+        int local_id = get_local_id(ix, 0, iz);
+        int collision_local_id =
+            nx_ * ny_ + (iz - 1) * (2 * nx_ + 2 * (ny_ - 2)) + ix;
+        collision_sphere_indices_(collision_local_id) = local_id;
+
+        local_id = get_local_id(ix, ny_ - 1, iz);
+        collision_local_id = nx_ * ny_ + (iz - 1) * (2 * nx_ + 2 * (ny_ - 2)) +
+                             nx_ + 2 * (ny_ - 2) + ix;
+        collision_sphere_indices_(collision_local_id) = local_id;
+      });
+
+  Kokkos::parallel_for(
+      Kokkos::MDRangePolicy<Kokkos::Rank<2> >{{1, 1}, {ny_ - 1, nz_ - 1}},
+      KOKKOS_LAMBDA(int iy, int iz) {
+        int local_id = get_local_id(0, iy, iz);
+        int collision_local_id = nx_ * ny_ +
+                                 (iz - 1) * (2 * nx_ + 2 * (ny_ - 2)) + nx_ +
+                                 2 * (iy - 1);
+        collision_sphere_indices_(collision_local_id) = local_id;
+
+        local_id = get_local_id(nx_ - 1, iy, iz);
+        collision_local_id = nx_ * ny_ + (iz - 1) * (2 * nx_ + 2 * (ny_ - 2)) +
+                             nx_ + 2 * (iy - 1) + 1;
+        collision_sphere_indices_(collision_local_id) = local_id;
+      });
+}
+
+void
+GranularObject::allocate_collision_spheres() {
+  const std::string view_name = object_name_ + "_collision_spheres";
+  collision_spheres_ =
+      bvh::view<CollisionSphere *>(view_name, collision_sphere_indices_.size());
+}
+
+void
+GranularObject::copy_collision_spheres() {
+  Kokkos::parallel_for(
+      Kokkos::RangePolicy<>(0, collision_sphere_indices_.size()),
+      KOKKOS_LAMBDA(int i) {
+        collision_spheres_(i) = spheres_(collision_sphere_indices_(i));
+      });
+}
+
+void
+GranularObject::step(const double &dt) {
+  const bvh::m::vec3d gravity(0.0, 0.0, -10.0);
+
+  velocity_ += dt * gravity;
+
+  Kokkos::parallel_for(
+      Kokkos::RangePolicy<>(0, spheres_.size()),
+      KOKKOS_LAMBDA(int i) { spheres_(i).update_position(dt, velocity_); });
+
+  copy_collision_spheres();
+}

--- a/examples/spheres/granular_object.hpp
+++ b/examples/spheres/granular_object.hpp
@@ -1,0 +1,119 @@
+/*
+ * distBVH 1.0
+ *
+ * Copyright 2023 National Technology & Engineering Solutions of Sandia, LLC
+ * (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+ * Government retains certain rights in this software.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS”
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef GRANULAR_OBJECT_HPP
+#define GRANULAR_OBJECT_HPP
+
+#include <bvh/math/vec.hpp>
+#include <cstddef>
+#include <string>
+
+#include "collision_sphere.hpp"
+#include "sphere.hpp"
+
+class GranularObject {
+public:
+  GranularObject(const std::string &object_name,
+                 const int &nx,
+                 const int &ny,
+                 const int &nz,
+                 const int &global_id_offset = 0,
+                 const bvh::m::vec3d &shift = bvh::m::vec3d::zeros())
+      : object_name_(object_name),
+        nx_(nx),
+        ny_(ny),
+        nz_(nz),
+        spheres_(),
+        collision_sphere_indices_(),
+        collision_spheres_(),
+        velocity_(bvh::m::vec3d::zeros()) {
+    generate_spheres(global_id_offset, shift);
+    compute_collision_sphere_indices();
+    allocate_collision_spheres();
+    copy_collision_spheres();
+  }
+
+  const bvh::m::vec3d &
+  position() const {
+    return spheres_(0).position();
+  }
+
+  const bvh::m::vec3d &
+  velocity() const {
+    return velocity_;
+  }
+
+  void
+  set_velocity(const bvh::m::vec3d &velocity) {
+    velocity_ = velocity;
+  }
+
+  void
+  step(const double &dt);
+
+  bvh::view<CollisionSphere *>
+  collision_spheres() const {
+    return collision_spheres_;
+  }
+
+private:
+  int
+  get_local_id(const int &ix, const int &iy, const int &iz) {
+    return ix + iy * nx_ + iz * nx_ * ny_;
+  }
+
+  void
+  generate_spheres(const int &global_id_offset, const bvh::m::vec3d &offset);
+
+  void
+  compute_collision_sphere_indices();
+
+  void
+  allocate_collision_spheres();
+
+  void
+  copy_collision_spheres();
+
+private:
+  const std::string object_name_;
+  const int nx_;
+  const int ny_;
+  const int nz_;
+  bvh::view<Sphere *> spheres_;
+  Kokkos::View<int *> collision_sphere_indices_;
+  bvh::view<CollisionSphere *> collision_spheres_;
+  bvh::m::vec3d velocity_;
+};
+
+#endif

--- a/examples/spheres/granular_object_test.cpp
+++ b/examples/spheres/granular_object_test.cpp
@@ -1,0 +1,118 @@
+/*
+ * distBVH 1.0
+ *
+ * Copyright 2023 National Technology & Engineering Solutions of Sandia, LLC
+ * (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+ * Government retains certain rights in this software.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS”
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "granular_object.hpp"
+
+#include <vt/vt.h>
+
+#include <Kokkos_Core.hpp>
+#include <iostream>
+#include <string>
+
+struct Config {
+  Config(int argc, char **argv);
+
+  int num_sphere_x = 5;
+  int num_sphere_y = 5;
+  int num_sphere_z = 5;
+};
+
+Config::Config(int argc, char **argv) {
+  for (int i = 1; i < argc; ++i) {
+    std::string arg = argv[i];
+    if (arg == "--num_sphere_x") {
+      num_sphere_x = std::stoi(argv[++i]);
+
+      if (num_sphere_x < 1) {
+        throw std::invalid_argument(
+            "number of spheres along x direction must be positive");
+      }
+    } else if (arg == "--num_sphere_y") {
+      num_sphere_y = std::stoi(argv[++i]);
+
+      if (num_sphere_y < 1) {
+        throw std::invalid_argument(
+            "number of spheres along y direction must be positive");
+      }
+    } else if (arg == "--num_sphere_z") {
+      num_sphere_z = std::stoi(argv[++i]);
+
+      if (num_sphere_z < 1) {
+        throw std::invalid_argument(
+            "number of spheres along z direction must be positive");
+      }
+    } else {
+      std::cerr << "ignoring unknown option \"" << arg << "\"\n";
+    }
+  }
+}
+
+void
+Main(const Config &config) {
+  const int &num_sphere_x = config.num_sphere_x;
+  const int &num_sphere_y = config.num_sphere_y;
+  const int &num_sphere_z = config.num_sphere_z;
+
+  GranularObject object("object", num_sphere_x, num_sphere_y, num_sphere_z);
+}
+
+int
+main(int argc, char **argv) {
+  int return_code = 0;
+  std::string error_message = "";
+
+  vt::initialize(argc, argv);
+  Kokkos::initialize(argc, argv);
+
+  try {
+    Config config(argc, argv);
+    Main(config);
+    return_code = 0;
+  } catch (std::exception &e) {
+    error_message = e.what();
+    return_code = 1;
+  } catch (...) {
+    error_message = "encountered unknown exception";
+    return_code = 1;
+  }
+
+  Kokkos::finalize();
+  vt::finalize();
+
+  if (return_code) {
+    std::cerr << error_message << std::endl;
+  }
+
+  return return_code;
+}

--- a/examples/spheres/sphere.hpp
+++ b/examples/spheres/sphere.hpp
@@ -1,0 +1,97 @@
+/*
+ * distBVH 1.0
+ *
+ * Copyright 2023 National Technology & Engineering Solutions of Sandia, LLC
+ * (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+ * Government retains certain rights in this software.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS”
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SPHERE_HPP
+#define SPHERE_HPP
+
+#include <bvh/math/vec.hpp>
+
+class Sphere {
+public:
+  KOKKOS_INLINE_FUNCTION Sphere() = default;
+
+  KOKKOS_INLINE_FUNCTION ~Sphere() = default;
+
+  Sphere(const Sphere &) = default;
+
+  Sphere(Sphere &&) noexcept = default;
+
+  KOKKOS_INLINE_FUNCTION Sphere &
+  operator=(const Sphere &) = default;
+
+  KOKKOS_INLINE_FUNCTION Sphere &
+  operator=(Sphere &&) noexcept = default;
+
+  void
+  set_global_id(const int &global_id) {
+    global_id_ = global_id;
+  }
+
+  void
+  set_radius(const double &radius) {
+    radius_ = radius;
+  }
+
+  void
+  set_position(const bvh::m::vec3d &position) {
+    position_ = position;
+  }
+
+  void
+  update_position(const double &dt, const bvh::m::vec3d &velocity) {
+    position_ += dt * velocity;
+  }
+
+  const int &
+  global_id() const {
+    return global_id_;
+  }
+
+  const double &
+  radius() const {
+    return radius_;
+  }
+
+  const bvh::m::vec3d &
+  position() const {
+    return position_;
+  }
+
+private:
+  int global_id_;
+  double radius_;
+  bvh::m::vec3d position_;
+};
+
+#endif

--- a/src/bvh/kdop.hpp
+++ b/src/bvh/kdop.hpp
@@ -121,7 +121,7 @@ namespace bvh
   BVH_INLINE constexpr bool overlap( const extent< T > &_lhs,
                                  const extent< T > &_rhs ) noexcept
   {
-    return _lhs.min < _rhs.max && _rhs.min < _lhs.max;
+    return _lhs.min <= _rhs.max && _rhs.min <= _lhs.max;
   }
 
   /**

--- a/src/bvh/kdop.hpp
+++ b/src/bvh/kdop.hpp
@@ -121,7 +121,7 @@ namespace bvh
   BVH_INLINE constexpr bool overlap( const extent< T > &_lhs,
                                  const extent< T > &_rhs ) noexcept
   {
-    return _lhs.min <= _rhs.max && _rhs.min <= _lhs.max;
+    return _lhs.min < _rhs.max && _rhs.min < _lhs.max;
   }
 
   /**


### PR DESCRIPTION
Set up a simple example, where two blocks made up of spheres collide. One block is kept fixed, while the other falls under gravity, collides with the first, and bounces back. As more MPI ranks are used, the objects are extended along the x direction. Controllable parameters are:

- `num_sphere_{x,y,z}`: (average) number of spheres per MPI rank in each object.
- `imbalance_x`: a integer between `0` and `num_sphere_x/2`, that, when positive, modifies the distribution of one of the objects along x direction over MPI ranks so that the partition boundaries do not match up exactly.
- `step_size`, `num_step`: step size and number of steps in forward Euler time integration.