### PR TITLE
#11: convert narrowphase data structures to Kokkos::View

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,8 @@ target_link_libraries(bvh PUBLIC Kokkos::kokkos)
 if (Kokkos_ENABLE_CUDA)
   message(STATUS "Enabling CUDA support")
   target_compile_definitions(bvh PUBLIC BVH_ENABLE_CUDA)
+  # FIXME_CUDA: this could silence a lot of warnings, but causes build failure
+  # target_compile_options(bvh PUBLIC --expt-relaxed-constexpr)
 endif()
 
 find_package(spdlog 1.13 REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,8 +112,6 @@ target_link_libraries(bvh PUBLIC Kokkos::kokkos)
 if (Kokkos_ENABLE_CUDA)
   message(STATUS "Enabling CUDA support")
   target_compile_definitions(bvh PUBLIC BVH_ENABLE_CUDA)
-  # FIXME_CUDA: this could silence a lot of warnings, but causes build failure
-  # target_compile_options(bvh PUBLIC --expt-relaxed-constexpr)
 endif()
 
 find_package(spdlog 1.13 REQUIRED)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ BVH requires a compiler that supports C++17. This includes at least clang 5 or g
 
 BVH uses [DARMA/vt](https://github.com/DARMA-tasking/vt) for asynchronous tasking. For more information about DARMA/vt
 please consult the [documentation](https://darma-tasking.github.io/docs/html/index.html).
-BVH requires [Kokkos](https://github.com/kokkos/kokkos) version `4.1` or later.
+BVH requires [Kokkos](https://github.com/kokkos/kokkos) version `4.4` or later.
 
 VTK can also be used for visualizing the the tree data structure.
 

--- a/ci/nimble_build_integration.sh
+++ b/ci/nimble_build_integration.sh
@@ -4,7 +4,7 @@ set -e
 mkdir -p /opt/src
 
 pushd /opt/src
-git clone -b 382-preallocate-view-before-parallel-for https://github.com/NimbleSM/NimbleSM.git
+git clone https://github.com/NimbleSM/NimbleSM.git
 mkdir -p /opt/builds/NimbleSM
 
 pushd /opt/builds/NimbleSM

--- a/ci/nimble_build_integration.sh
+++ b/ci/nimble_build_integration.sh
@@ -4,7 +4,7 @@ set -e
 mkdir -p /opt/src
 
 pushd /opt/src
-git clone https://github.com/NimbleSM/NimbleSM.git
+git clone -b 382-preallocate-view-before-parallel-for https://github.com/NimbleSM/NimbleSM.git
 mkdir -p /opt/builds/NimbleSM
 
 pushd /opt/builds/NimbleSM

--- a/src/bvh/collision_object.cpp
+++ b/src/bvh/collision_object.cpp
@@ -105,7 +105,8 @@ namespace bvh
 
   collision_object::~collision_object() = default;
 
-  void collision_object::set_entity_data_impl( bvh::view< const std::byte * > _data, std::size_t _element_size )
+  void collision_object::set_entity_data_impl( const bvh::unmanaged_view< const std::byte * > &_data,
+                                               std::size_t _element_size )
   {
     const int rank = static_cast< int >( ::vt::theContext()->getNode() );
     const auto od_factor = m_impl->overdecomposition;

--- a/src/bvh/collision_object.cpp
+++ b/src/bvh/collision_object.cpp
@@ -58,8 +58,9 @@ namespace bvh
       Kokkos::resize( Kokkos::WithoutInitializing, _coll->bytes, _msg->data_size );
 
       // Guard the memcpy because it's UB even if size is zero if the pointers are invalid
-      if ( _msg->data_size > 0 )
-        std::memcpy( _coll->bytes.data(), _msg->user_data(), _msg->data_size );
+      Kokkos::deep_copy( _coll->bytes, _msg->user_data() );
+      //if ( _msg->data_size > 0 )
+      //  std::memcpy( _coll->bytes.data(), _msg->user_data(), _msg->data_size );
       _coll->origin_node = _msg->origin_node;
 
       // Reset cache destinations
@@ -421,7 +422,7 @@ namespace bvh
     return m_impl->snapshots;
   }
 
-  host_view< bvh::entity_snapshot * > &collision_object::get_snapshots_h()
+  view< bvh::entity_snapshot * >::host_mirror_type &collision_object::get_snapshots_h()
   {
     return m_impl->snapshots_h;
   }
@@ -432,13 +433,19 @@ namespace bvh
     return m_impl->split_indices;
   }
 
+  view< std::size_t * >::host_mirror_type &
+  collision_object::get_split_indices_h()
+  {
+    return m_impl->split_indices_h;
+  }
+
   view< std::size_t * > &
   collision_object::get_splits()
   {
     return m_impl->splits;
   }
 
-  host_view< std::size_t * > &
+  view< std::size_t * >::host_mirror_type &
   collision_object::get_splits_h()
   {
     return m_impl->splits_h;

--- a/src/bvh/collision_object.cpp
+++ b/src/bvh/collision_object.cpp
@@ -55,7 +55,7 @@ namespace bvh
     {
       // Set data
       _coll->patch_meta = _msg->patch_meta;
-      _coll->bytes.resize( _msg->data_size );
+      Kokkos::resize( _coll->bytes, _msg->data_size );
 
       // Guard the memcpy because it's UB even if size is zero if the pointers are invalid
       if ( _msg->data_size > 0 )

--- a/src/bvh/collision_object.cpp
+++ b/src/bvh/collision_object.cpp
@@ -132,7 +132,7 @@ namespace bvh
 
     for ( std::size_t i = 0; i < od_factor; ++i ) {
       const auto sbeg = ( i == 0 ) ? 0 : m_impl->splits_h( i - 1 );
-      const auto send = ( i == m_impl->num_splits ) ? m_impl->split_indices_h.extent( 0 ) : m_impl->splits_h( i );
+      const auto send = ( i == m_impl->num_splits ) ? m_impl->split_indices.extent( 0 ) : m_impl->splits_h( i );
       const std::size_t nelements = send - sbeg;
       logger().debug( "creating broadphase patch for body {} size {} from offset {}", m_impl->collision_idx, nelements, sbeg );
       // FIXME_CUDA
@@ -433,12 +433,6 @@ namespace bvh
   }
 
   host_view< std::size_t * > &
-  collision_object::get_split_indices_h()
-  {
-    return m_impl->split_indices_h;
-  }
-
-  host_view< std::size_t * > &
   collision_object::get_splits_h()
   {
     return m_impl->splits_h;
@@ -454,7 +448,6 @@ namespace bvh
   collision_object::initialize_split_indices( const element_permutations &_splits )
   {
     Kokkos::resize( Kokkos::WithoutInitializing, m_impl->split_indices, _splits.indices.size() );
-    Kokkos::resize( Kokkos::WithoutInitializing, m_impl->split_indices_h, _splits.indices.size() );
     Kokkos::resize( Kokkos::WithoutInitializing, m_impl->splits, _splits.splits.size() );
     Kokkos::resize( Kokkos::WithoutInitializing, m_impl->splits_h, _splits.splits.size() );
 
@@ -462,7 +455,7 @@ namespace bvh
     Kokkos::View< const std::size_t *, bvh::host_execution_space, Kokkos::MemoryTraits< Kokkos::Unmanaged > > splits_view( _splits.splits.data(), _splits.splits.size() );
 
     Kokkos::deep_copy( m_impl->splits_h, splits_view );
-    Kokkos::deep_copy( m_impl->split_indices_h, indices_view );
+    Kokkos::deep_copy( m_impl->split_indices, indices_view );
   }
 
   spdlog::logger &

--- a/src/bvh/collision_object.cpp
+++ b/src/bvh/collision_object.cpp
@@ -105,7 +105,7 @@ namespace bvh
 
   collision_object::~collision_object() = default;
 
-  void collision_object::set_entity_data_impl( bvh::view< const unsigned char * > _data, std::size_t _element_size )
+  void collision_object::set_entity_data_impl( bvh::view< const std::byte * > _data, std::size_t _element_size )
   {
     const int rank = static_cast< int >( ::vt::theContext()->getNode() );
     const auto od_factor = m_impl->overdecomposition;

--- a/src/bvh/collision_object.cpp
+++ b/src/bvh/collision_object.cpp
@@ -55,7 +55,7 @@ namespace bvh
     {
       // Set data
       _coll->patch_meta = _msg->patch_meta;
-      Kokkos::resize( _coll->bytes, _msg->data_size );
+      Kokkos::resize( Kokkos::WithoutInitializing, _coll->bytes, _msg->data_size );
 
       // Guard the memcpy because it's UB even if size is zero if the pointers are invalid
       if ( _msg->data_size > 0 )

--- a/src/bvh/collision_object.cpp
+++ b/src/bvh/collision_object.cpp
@@ -106,8 +106,7 @@ namespace bvh
 
   collision_object::~collision_object() = default;
 
-  void collision_object::set_entity_data_impl( const bvh::unmanaged_view< const std::byte * > &_data,
-                                               std::size_t _element_size )
+  void collision_object::set_entity_data_impl( std::unique_ptr< detail::user_element_storage_base > &&_data )
   {
     const int rank = static_cast< int >( ::vt::theContext()->getNode() );
     const auto od_factor = m_impl->overdecomposition;
@@ -126,8 +125,7 @@ namespace bvh
     // Preallocate local data buffers. Do this lazily
     m_impl->narrowphase_patch_messages.resize( od_factor, nullptr );
 
-    m_impl->m_entity_ptr = _data;
-    m_impl->m_entity_unit_size = _element_size;
+    m_impl->m_user_data = std::move( _data );
 
     // Ensure that our update of m_impl->snapshots has finished before reading it here
     Kokkos::fence();

--- a/src/bvh/collision_object.cpp
+++ b/src/bvh/collision_object.cpp
@@ -136,7 +136,6 @@ namespace bvh
       const auto send = ( i == m_impl->num_splits ) ? m_impl->split_indices.extent( 0 ) : m_impl->splits_h( i );
       const std::size_t nelements = send - sbeg;
       logger().debug( "creating broadphase patch for body {} size {} from offset {}", m_impl->collision_idx, nelements, sbeg );
-      // FIXME_CUDA: should `span` be reworked to use Kokkos::View underneath?
       Kokkos::deep_copy( m_impl->snapshots_h, m_impl->snapshots );
       m_impl->local_patches[i] = broadphase_patch_type(
         i + rank * od_factor, span< const entity_snapshot >( m_impl->snapshots_h.data() + sbeg, nelements ) );

--- a/src/bvh/collision_object.cpp
+++ b/src/bvh/collision_object.cpp
@@ -461,14 +461,17 @@ namespace bvh
   collision_object::initialize_split_indices( const element_permutations &_splits )
   {
     Kokkos::resize( Kokkos::WithoutInitializing, m_impl->split_indices, _splits.indices.size() );
+    Kokkos::resize( Kokkos::WithoutInitializing, m_impl->split_indices_h, _splits.indices.size() );
     Kokkos::resize( Kokkos::WithoutInitializing, m_impl->splits, _splits.splits.size() );
     Kokkos::resize( Kokkos::WithoutInitializing, m_impl->splits_h, _splits.splits.size() );
 
     Kokkos::View< const std::size_t *, bvh::host_execution_space, Kokkos::MemoryTraits< Kokkos::Unmanaged > > indices_view( _splits.indices.data(), _splits.indices.size() );
     Kokkos::View< const std::size_t *, bvh::host_execution_space, Kokkos::MemoryTraits< Kokkos::Unmanaged > > splits_view( _splits.splits.data(), _splits.splits.size() );
 
-    Kokkos::deep_copy( m_impl->splits_h, splits_view );
+    Kokkos::deep_copy( m_impl->splits, splits_view );
     Kokkos::deep_copy( m_impl->split_indices, indices_view );
+    Kokkos::deep_copy( m_impl->splits_h, m_impl->splits);
+    Kokkos::deep_copy( m_impl->split_indices_h, m_impl->split_indices);
   }
 
   spdlog::logger &

--- a/src/bvh/collision_object.cpp
+++ b/src/bvh/collision_object.cpp
@@ -124,8 +124,7 @@ namespace bvh
     // Preallocate local data buffers. Do this lazily
     m_impl->narrowphase_patch_messages.resize( od_factor, nullptr );
 
-    // FIXME_CUDA
-    m_impl->m_entity_ptr = _data.data();
+    m_impl->m_entity_ptr = _data;
     m_impl->m_entity_unit_size = _element_size;
 
     // Ensure that our update of m_impl->snapshots has finished before reading it here

--- a/src/bvh/collision_object.cpp
+++ b/src/bvh/collision_object.cpp
@@ -105,7 +105,7 @@ namespace bvh
 
   collision_object::~collision_object() = default;
 
-  void collision_object::set_entity_data_impl( const void *_data, std::size_t _element_size )
+  void collision_object::set_entity_data_impl( bvh::view< const unsigned char * > _data, std::size_t _element_size )
   {
     const int rank = static_cast< int >( ::vt::theContext()->getNode() );
     const auto od_factor = m_impl->overdecomposition;
@@ -124,7 +124,7 @@ namespace bvh
     // Preallocate local data buffers. Do this lazily
     m_impl->narrowphase_patch_messages.resize( od_factor, nullptr );
 
-    m_impl->m_entity_ptr = static_cast< const unsigned char * >( _data );
+    m_impl->m_entity_ptr = _data.data();
     m_impl->m_entity_unit_size = _element_size;
 
     // Ensure that our update of m_impl->snapshots has finished before reading it here

--- a/src/bvh/collision_object.cpp
+++ b/src/bvh/collision_object.cpp
@@ -37,6 +37,7 @@
 #include "collision_object/top_down.hpp"
 #include "collision_object/broadphase.hpp"
 #include "collision_object/narrowphase.hpp"
+#include <Kokkos_Core.hpp>
 #include <unordered_map>
 
 namespace bvh
@@ -130,10 +131,39 @@ namespace bvh
     // Ensure that our update of m_impl->snapshots has finished before reading it here
     Kokkos::fence();
 
+    // REMOVE_ME: this is just to make sure they are in sync
+    Kokkos::deep_copy( m_impl->splits_h, m_impl->splits );
+
     for ( std::size_t i = 0; i < od_factor; ++i ) {
       const auto sbeg = ( i == 0 ) ? 0 : m_impl->splits_h( i - 1 );
       const auto send = ( i == m_impl->num_splits ) ? m_impl->split_indices.extent( 0 ) : m_impl->splits_h( i );
+      logger().warn( "m_impl->splits_h( 0 ): {}\t", m_impl->splits_h( 0 ) );
       const std::size_t nelements = send - sbeg;
+      // FIXME: differences between GPU and CPU run
+      //
+      // CPU:
+      // [collision_object] [info] initialized collision object 0
+      // [collision_object] [debug] obj=0 clustering 96 elements
+      // [collision_object] [warning] sbeg: 0       send: 47
+      // [collision_object] [debug] creating broadphase patch for body 0 size 47 from offset 0
+      // [collision_object] [warning] sbeg: 47      send: 96
+      // [collision_object] [debug] creating broadphase patch for body 0 size 49 from offset 47
+      //
+      // GPU:
+      // [collision_object] [info] initialized collision object 0
+      // [collision_object] [debug] obj=0 clustering 96 elements
+      // [collision_object] [warning] sbeg: 0	 send: 0
+      // [collision_object] [debug] creating broadphase patch for body 0 size 0 from offset 0
+      // [collision_object] [warning] sbeg: 0	 send: 96
+      // [collision_object] [debug] creating broadphase patch for body 0 size 96 from offset 0
+      //
+      // We later run into:
+      // /distBVH/tests/collision_object_test.cpp:54: FAILED:
+      //   REQUIRE( _tree.count() == od_factor * nranks )
+      // with expansion:
+      //   1 == 2
+      //
+      logger().warn( "sbeg: {}\t send: {}\t", sbeg, send );
       logger().debug( "creating broadphase patch for body {} size {} from offset {}", m_impl->collision_idx, nelements, sbeg );
       // FIXME_CUDA: should `span` be reworked to use Kokkos::View underneath?
       Kokkos::deep_copy( m_impl->snapshots_h, m_impl->snapshots );
@@ -460,6 +490,8 @@ namespace bvh
     Kokkos::View< const std::size_t *, bvh::host_execution_space, Kokkos::MemoryTraits< Kokkos::Unmanaged > > indices_view( _splits.indices.data(), _splits.indices.size() );
     Kokkos::View< const std::size_t *, bvh::host_execution_space, Kokkos::MemoryTraits< Kokkos::Unmanaged > > splits_view( _splits.splits.data(), _splits.splits.size() );
 
+    // FIXME: copy to m_impl->splits too?
+    // Kokkos::deep_copy(m_impl->splits, splits_view);
     Kokkos::deep_copy( m_impl->splits_h, splits_view );
     Kokkos::deep_copy( m_impl->split_indices, indices_view );
   }

--- a/src/bvh/collision_object.cpp
+++ b/src/bvh/collision_object.cpp
@@ -123,7 +123,6 @@ namespace bvh
 
     // Preallocate local data buffers. Do this lazily
     m_impl->narrowphase_patch_messages.resize( od_factor, nullptr );
-    auto range_policy = Kokkos::RangePolicy< Kokkos::Serial >( 0, od_factor );
 
     m_impl->m_entity_ptr = static_cast< const unsigned char * >( _data );
     m_impl->m_entity_unit_size = _element_size;

--- a/src/bvh/collision_object.cpp
+++ b/src/bvh/collision_object.cpp
@@ -136,6 +136,7 @@ namespace bvh
       const auto send = ( i == m_impl->num_splits ) ? m_impl->split_indices_h.extent( 0 ) : m_impl->splits_h( i );
       const std::size_t nelements = send - sbeg;
       logger().debug( "creating broadphase patch for body {} size {} from offset {}", m_impl->collision_idx, nelements, sbeg );
+      // FIXME_CUDA
       m_impl->local_patches[i] = broadphase_patch_type(
         i + rank * od_factor, span< const entity_snapshot >( m_impl->snapshots.data() + sbeg, nelements ) );
     }

--- a/src/bvh/collision_object.cpp
+++ b/src/bvh/collision_object.cpp
@@ -236,13 +236,16 @@ namespace bvh
       return pending_send{ ::vt::no_epoch, [this, _fun, _idx](){
         if ( _idx == vt_index{ 0UL } )  // first index
         {
-          for ( auto &&res : m_impl->local_results )
-          {
-            _fun( res );
-          }
+          _fun( m_impl->local_results );
         }
       } };
     } );
+  }
+
+  narrowphase_result
+  collision_object::get_narrowphase_results_impl() const
+  {
+    return m_impl->local_results;
   }
 
   void

--- a/src/bvh/collision_object.cpp
+++ b/src/bvh/collision_object.cpp
@@ -57,10 +57,7 @@ namespace bvh
       _coll->patch_meta = _msg->patch_meta;
       Kokkos::resize( Kokkos::WithoutInitializing, _coll->bytes, _msg->data_size );
 
-      // Guard the memcpy because it's UB even if size is zero if the pointers are invalid
       Kokkos::deep_copy( _coll->bytes, _msg->user_data() );
-      //if ( _msg->data_size > 0 )
-      //  std::memcpy( _coll->bytes.data(), _msg->user_data(), _msg->data_size );
       _coll->origin_node = _msg->origin_node;
 
       // Reset cache destinations

--- a/src/bvh/collision_object.hpp
+++ b/src/bvh/collision_object.hpp
@@ -125,8 +125,7 @@ namespace bvh
       // This assumes _data_view is on host for now... at the moment we can't do much better
       {
         ::vt::trace::TraceScopedEvent scope( this->bvh_set_entity_data_impl_ );
-        set_entity_data_impl( reinterpret_cast< Kokkos::View< const unsigned char *, ViewProp... > & >( _data_view ),
-                              sizeof( T ) );
+        set_entity_data_impl( get_bytes( _data_view ), sizeof( T ) );
       }
     }
 
@@ -146,8 +145,7 @@ namespace bvh
       }
       {
         ::vt::trace::TraceScopedEvent scope( this->bvh_set_entity_data_impl_ );
-        set_entity_data_impl( reinterpret_cast< Kokkos::View< const unsigned char *, ViewProp... > & >( _data ),
-                              sizeof( T ) );
+        set_entity_data_impl( get_bytes( _data ), sizeof( T ) );
       }
     }
 
@@ -206,8 +204,7 @@ namespace bvh
 
       update_snapshots( _data );
 
-      set_entity_data_impl( reinterpret_cast< Kokkos::View< const unsigned char *, ViewProp... > & >( _data ),
-                            sizeof( T ) );
+      set_entity_data_impl( get_bytes( _data ), sizeof( T ) );
       std::move( _trace ).end();
     }
 
@@ -217,7 +214,14 @@ namespace bvh
     ///
     /// \param[in] _data
     /// \param[in] _element_size
-    void set_entity_data_impl( bvh::view< const unsigned char * > _data, std::size_t _element_size );
+    void set_entity_data_impl( bvh::view< const std::byte * > _data, std::size_t _element_size );
+
+    template< typename T, typename... ViewProp >
+    Kokkos::View< const std::byte *, ViewProp... > get_bytes( Kokkos::View< const T *, ViewProp... > _data )
+    {
+      return Kokkos::View< const std::byte *, ViewProp... >( reinterpret_cast< const std::byte * >( _data.data() ),
+                                                             _data.size() * sizeof( T ) / sizeof( std::byte ) );
+    }
 
     void set_all_narrow_patches();
     void set_active_narrow_patches();

--- a/src/bvh/collision_object.hpp
+++ b/src/bvh/collision_object.hpp
@@ -236,7 +236,9 @@ namespace bvh
     {
       // No-op if the view is the same size, which is typically the case
       auto &snap = get_snapshots();
+      auto &snap_h = get_snapshots_h();
       Kokkos::resize( Kokkos::WithoutInitializing, snap, _data_view.extent( 0 ) );
+      Kokkos::resize( Kokkos::WithoutInitializing, snap_h, _data_view.extent( 0 ) );
       auto &ind = get_split_indices();
       Kokkos::parallel_for(
         ind.extent( 0 ), KOKKOS_LAMBDA( int _idx ) {
@@ -250,7 +252,9 @@ namespace bvh
     {
       // No-op if the view is the same size, which is typically the case
       auto &snap = get_snapshots();
+      auto &snap_h = get_snapshots_h();
       Kokkos::resize( Kokkos::WithoutInitializing, snap, _data_view.extent( 0 ) );
+      Kokkos::resize( Kokkos::WithoutInitializing, snap_h, _data_view.extent( 0 ) );
       Kokkos::parallel_for(
         _data_view.extent( 0 ), KOKKOS_LAMBDA( int _idx ) {
           snap( _idx ) = make_snapshot( _data_view( _idx ), static_cast< std::size_t >( _idx ) );
@@ -263,6 +267,7 @@ namespace bvh
     void for_each_result_impl( std::function< void(const narrowphase_result &) > &&_fun );
 
     view< bvh::entity_snapshot * > &get_snapshots();
+    host_view< bvh::entity_snapshot * > &get_snapshots_h();
     view< std::size_t * > &get_split_indices();
     view< std::size_t * > &get_splits();
     host_view< std::size_t * > &get_splits_h();

--- a/src/bvh/collision_object.hpp
+++ b/src/bvh/collision_object.hpp
@@ -219,8 +219,9 @@ namespace bvh
 
     template< typename T > auto get_bytes( bvh::view< const T * > _data )
     {
-      return bvh::unmanaged_view< const std::byte * >( reinterpret_cast< const std::byte * >( _data.data() ),
-                                                       _data.size() * sizeof( T ) / sizeof( std::byte ) );
+      return bvh::unmanaged_view< const std::byte * >(
+        reinterpret_cast< const std::byte * >( _data.data() ),
+        _data.size() * sizeof( T ) / sizeof( std::byte ) );  // FIXME_CUDA: should we use _data.span()?
     }
 
     void set_all_narrow_patches();

--- a/src/bvh/collision_object.hpp
+++ b/src/bvh/collision_object.hpp
@@ -217,10 +217,10 @@ namespace bvh
     /// \param[in] _element_size
     void set_entity_data_impl( const bvh::unmanaged_view< const std::byte * > &_data, std::size_t _element_size );
 
-    template< typename T, typename... ViewProp > auto get_bytes( Kokkos::View< const T *, ViewProp... > _data )
+    template< typename T > auto get_bytes( bvh::view< const T * > _data )
     {
-      return Kokkos::View< const std::byte *, ViewProp..., Kokkos::MemoryTraits< Kokkos::Unmanaged > >(
-        reinterpret_cast< const std::byte * >( _data.data() ), _data.size() * sizeof( T ) / sizeof( std::byte ) );
+      return bvh::unmanaged_view< const std::byte * >( reinterpret_cast< const std::byte * >( _data.data() ),
+                                                       _data.size() * sizeof( T ) / sizeof( std::byte ) );
     }
 
     void set_all_narrow_patches();

--- a/src/bvh/collision_object.hpp
+++ b/src/bvh/collision_object.hpp
@@ -126,6 +126,7 @@ namespace bvh
       // This assumes _data_view is on host for now... at the moment we can't do much better
       {
         ::vt::trace::TraceScopedEvent scope( this->bvh_set_entity_data_impl_ );
+        // FIXME_CUDA
         set_entity_data_impl( _data_view.data(), sizeof( T ) );
       }
     }
@@ -235,6 +236,7 @@ namespace bvh
       // No-op if the view is the same size, which is typically the case
       auto &snap = get_snapshots();
       Kokkos::resize( Kokkos::WithoutInitializing, snap, _data_view.extent( 0 ) );
+      // FIXME_CUDA
       auto &ind = get_split_indices_h();
       Kokkos::parallel_for(
         ind.extent( 0 ), KOKKOS_LAMBDA( int _idx ) {

--- a/src/bvh/collision_object.hpp
+++ b/src/bvh/collision_object.hpp
@@ -103,16 +103,17 @@ namespace bvh
         {
           m_clusterer.resize( n );
         }
-        Kokkos::resize( Kokkos::WithoutInitializing, get_split_indices(), n );
+        auto &ind = get_split_indices();
+        Kokkos::resize( Kokkos::WithoutInitializing, ind, n );
 
         Kokkos::resize( Kokkos::WithoutInitializing, get_splits(), num_splits );
         Kokkos::resize( Kokkos::WithoutInitializing, get_splits_h(), num_splits );
 
         // Initialize our indices
-        auto split_indices = get_split_indices();
-        Kokkos::parallel_for( n, KOKKOS_LAMBDA( int _i ) { split_indices( _i ) = _i; } );
+        Kokkos::parallel_for(
+          n, KOKKOS_LAMBDA( int _i ) { ind( _i ) = _i; } );
 
-        m_clusterer( _data_view, get_split_indices(), get_splits() );
+        m_clusterer( _data_view, ind, get_splits() );
 
         Kokkos::deep_copy( get_splits_h(), get_splits() );
 

--- a/src/bvh/collision_object.hpp
+++ b/src/bvh/collision_object.hpp
@@ -125,8 +125,8 @@ namespace bvh
       // This assumes _data_view is on host for now... at the moment we can't do much better
       {
         ::vt::trace::TraceScopedEvent scope( this->bvh_set_entity_data_impl_ );
-        // FIXME_CUDA
-        set_entity_data_impl( _data_view.data(), sizeof( T ) );
+        set_entity_data_impl( reinterpret_cast< Kokkos::View< const unsigned char *, ViewProp... > & >( _data_view ),
+                              sizeof( T ) );
       }
     }
 
@@ -146,7 +146,8 @@ namespace bvh
       }
       {
         ::vt::trace::TraceScopedEvent scope( this->bvh_set_entity_data_impl_ );
-        set_entity_data_impl( _data.data(), sizeof( T ) );
+        set_entity_data_impl( reinterpret_cast< Kokkos::View< const unsigned char *, ViewProp... > & >( _data ),
+                              sizeof( T ) );
       }
     }
 
@@ -205,7 +206,8 @@ namespace bvh
 
       update_snapshots( _data );
 
-      set_entity_data_impl( _data.data(), sizeof( T ) );
+      set_entity_data_impl( reinterpret_cast< Kokkos::View< const unsigned char *, ViewProp... > & >( _data ),
+                            sizeof( T ) );
       std::move( _trace ).end();
     }
 
@@ -215,7 +217,7 @@ namespace bvh
     ///
     /// \param[in] _data
     /// \param[in] _element_size
-    void set_entity_data_impl( const void *_data, std::size_t _element_size );
+    void set_entity_data_impl( bvh::view< const unsigned char * > _data, std::size_t _element_size );
 
     void set_all_narrow_patches();
     void set_active_narrow_patches();

--- a/src/bvh/collision_object.hpp
+++ b/src/bvh/collision_object.hpp
@@ -109,8 +109,8 @@ namespace bvh
         Kokkos::resize( Kokkos::WithoutInitializing, get_splits_h(), num_splits );
 
         // Initialize our indices
-        Kokkos::parallel_for(
-          n, KOKKOS_LAMBDA( int _i ) { get_split_indices()( _i ) = _i; } );
+        auto split_indices = get_split_indices();
+        Kokkos::parallel_for( n, KOKKOS_LAMBDA( int _i ) { split_indices( _i ) = _i; } );
 
         m_clusterer( _data_view, get_split_indices(), get_splits() );
 

--- a/src/bvh/collision_object.hpp
+++ b/src/bvh/collision_object.hpp
@@ -46,6 +46,7 @@
 #include "split/axis.hpp"
 #include "tree_build.hpp"
 #include "types.hpp"
+#include "util/kokkos.hpp"
 #include "util/span.hpp"
 #include "split/cluster.hpp"
 
@@ -214,13 +215,12 @@ namespace bvh
     ///
     /// \param[in] _data
     /// \param[in] _element_size
-    void set_entity_data_impl( bvh::view< const std::byte * > _data, std::size_t _element_size );
+    void set_entity_data_impl( const bvh::unmanaged_view< const std::byte * > &_data, std::size_t _element_size );
 
-    template< typename T, typename... ViewProp >
-    Kokkos::View< const std::byte *, ViewProp... > get_bytes( Kokkos::View< const T *, ViewProp... > _data )
+    template< typename T, typename... ViewProp > auto get_bytes( Kokkos::View< const T *, ViewProp... > _data )
     {
-      return Kokkos::View< const std::byte *, ViewProp... >( reinterpret_cast< const std::byte * >( _data.data() ),
-                                                             _data.size() * sizeof( T ) / sizeof( std::byte ) );
+      return Kokkos::View< const std::byte *, ViewProp..., Kokkos::MemoryTraits< Kokkos::Unmanaged > >(
+        reinterpret_cast< const std::byte * >( _data.data() ), _data.size() * sizeof( T ) / sizeof( std::byte ) );
     }
 
     void set_all_narrow_patches();

--- a/src/bvh/collision_object.hpp
+++ b/src/bvh/collision_object.hpp
@@ -110,8 +110,7 @@ namespace bvh
         Kokkos::resize( Kokkos::WithoutInitializing, get_splits_h(), num_splits );
 
         // Initialize our indices
-        Kokkos::parallel_for(
-          n, KOKKOS_LAMBDA( int _i ) { ind( _i ) = _i; } );
+        Kokkos::parallel_for( n, KOKKOS_LAMBDA( int _i ) { ind( _i ) = _i; } );
 
         m_clusterer( _data_view, ind, get_splits() );
 

--- a/src/bvh/collision_object.hpp
+++ b/src/bvh/collision_object.hpp
@@ -248,12 +248,12 @@ namespace bvh
 
     std::size_t id() const noexcept;
 
-    template< typename ResultType, typename F > void for_each_result( F &&_fun )
+    template< typename ResultType, typename F > void for_each_result( const F &_fun )
     {
-      for_each_result_impl( [&_fun]( const narrowphase_result &_res ) {
+      for_each_result_impl( [_fun]( const narrowphase_result &_res ) {
         for ( std::size_t i = 0; i < _res.size(); ++i )
         {
-          std::forward< F >( _fun )( *reinterpret_cast< const ResultType * >( _res.at( i ) ) );
+          std::invoke( _fun, *reinterpret_cast< const ResultType * >( _res.at( i ) ) );
         }
       } );
     }

--- a/src/bvh/collision_object.hpp
+++ b/src/bvh/collision_object.hpp
@@ -100,7 +100,7 @@ namespace bvh
       std::size_t offset = 0;
       for ( std::size_t j = _begin; j < _end; ++j )
       {
-        debug_assert( offset + sizeof( T ) < max_size_bytes, "split index offset={} is out of bounds (local data size is {})",
+        debug_assert( offset + sizeof( T ) <= max_size_bytes, "split index offset={} is out of bounds (local data size is {})",
                       offset, max_size_bytes );
         const std::size_t user_index = _split_indices( j );
         debug_assert( user_index < m_host_user_data.extent( 0 ), "user index is out of bounds" );

--- a/src/bvh/collision_object.hpp
+++ b/src/bvh/collision_object.hpp
@@ -40,6 +40,7 @@
 #include <vt/context/context.h>
 #include <spdlog/spdlog.h>
 
+#include "collision_query.hpp"
 #include "snapshot.hpp"
 #include "split/split.hpp"
 #include "split/mean.hpp"
@@ -251,10 +252,19 @@ namespace bvh
     template< typename ResultType, typename F > void for_each_result( const F &_fun )
     {
       for_each_result_impl( [_fun]( const narrowphase_result &_res ) {
+        auto res = typed_narrowphase_result< ResultType >{ _res };
         for ( std::size_t i = 0; i < _res.size(); ++i )
         {
-          std::invoke( _fun, *reinterpret_cast< const ResultType * >( _res.at( i ) ) );
+          std::invoke( _fun, res[i] );
         }
+      } );
+    }
+
+    template< typename ResultType, typename F >
+    void with_narrowphase_results( const F &_fun )
+    {
+      for_each_result_impl( [_fun]( const narrowphase_result &_res ) {
+        std::invoke( _fun, typed_narrowphase_result< ResultType >{ _res } );
       } );
     }
 
@@ -334,6 +344,7 @@ namespace bvh
 
     void for_each_tree_impl( tree_function &&_fun );
     void for_each_result_impl( std::function< void( const narrowphase_result & ) > &&_fun );
+    narrowphase_result get_narrowphase_results_impl() const;
 
     view< bvh::entity_snapshot * > &get_snapshots();
     view< bvh::entity_snapshot * >::host_mirror_type &get_snapshots_h();

--- a/src/bvh/collision_object/impl.cpp
+++ b/src/bvh/collision_object/impl.cpp
@@ -42,7 +42,6 @@ namespace bvh
       snapshots( fmt::format( "contact entity {} snapshot", _idx ), 0 ),
       split_indices( fmt::format( "contact entity {} split indices", _idx ), 0 ),
       splits( fmt::format( "contact entity {} splits", _idx ), 0 ),
-      split_indices_h( fmt::format( "contact entity host {} split indices", _idx ), 0 ),
       splits_h( fmt::format( "contact entity host {} splits", _idx ), 0 ),
       logger( _world.collision_object_logger() ),
       broadphase_logger( _world.collision_object_broadphase_logger() ),

--- a/src/bvh/collision_object/impl.cpp
+++ b/src/bvh/collision_object/impl.cpp
@@ -40,6 +40,7 @@ namespace bvh
     : world( &_world ),
       collision_idx( _idx ),
       snapshots( fmt::format( "contact entity {} snapshot", _idx ), 0 ),
+      snapshots_h( fmt::format( "contact entity host {} snapshot", _idx ), 0 ),
       split_indices( fmt::format( "contact entity {} split indices", _idx ), 0 ),
       splits( fmt::format( "contact entity {} splits", _idx ), 0 ),
       splits_h( fmt::format( "contact entity host {} splits", _idx ), 0 ),

--- a/src/bvh/collision_object/impl.cpp
+++ b/src/bvh/collision_object/impl.cpp
@@ -321,9 +321,8 @@ namespace bvh
       {
         ::vt::trace::TraceScopedEvent scope( world_impl.bvh_impl_functor_ );
         auto r = world_impl.functor( this_obj, this_cache.meta, static_cast< std::size_t >( idx[0] ),
-                                     this_cache.patch_data.data(), this_cache.patch_data.size(), other_obj,
-                                     other_cache.meta, static_cast< std::size_t >( idx[2] ),
-                                     other_cache.patch_data.data(), other_cache.patch_data.size() );
+                                     this_cache.patch_data, other_obj, other_cache.meta,
+                                     static_cast< std::size_t >( idx[2] ), other_cache.patch_data );
 
         if ( r.a.size() > 0 )
         {

--- a/src/bvh/collision_object/impl.cpp
+++ b/src/bvh/collision_object/impl.cpp
@@ -166,6 +166,8 @@ namespace bvh
 
     void collision_object_holder::set_result( result_msg *_msg )
     {
+      auto &logger = self->narrowphase_logger();
+      logger.info( "obj={} adding result of size {} to results vector of size {}", self->get_impl().collision_idx, _msg->result.size(), self->get_impl().local_results.size() );
       self->get_impl().local_results.emplace_back( _msg->result );
     }
 
@@ -328,8 +330,8 @@ namespace bvh
         {
           auto lmsg = ::vt::makeMessage< result_msg >();
           lmsg->result = std::move( r.a );
-          logger.trace( "<send={}> result from <obj {}, patch {} | obj {}, patch {}>",
-                        left_node, this_obj.id(), idx[0], idx[1], idx[2] );
+          logger.trace( "<send={}> result from <obj {}, patch {} | obj {}, patch {} ({} hits)>",
+                        left_node, this_obj.id(), idx[0], idx[1], idx[2], lmsg->result.size() );
           this_obj.get_impl()
             .objgroup[left_node]
             .sendMsg< result_msg, &collision_object_impl::collision_object_holder::set_result >( lmsg );

--- a/src/bvh/collision_object/impl.cpp
+++ b/src/bvh/collision_object/impl.cpp
@@ -167,8 +167,8 @@ namespace bvh
     void collision_object_holder::set_result( result_msg *_msg )
     {
       auto &logger = self->narrowphase_logger();
-      logger.info( "obj={} adding result of size {} to results vector of size {}", self->get_impl().collision_idx, _msg->result.size(), self->get_impl().local_results.size() );
-      self->get_impl().local_results.emplace_back( _msg->result );
+      logger.info( "obj={} adding result of size {} to results of size {}", self->get_impl().collision_idx, _msg->result.size(), self->get_impl().local_results.size() );
+      self->get_impl().local_results.extend( _msg->result );
     }
 
     void activate_narrowphase( collision_object_impl::narrowphase_collection_type *_narrow, activate_narrowphase_msg *_msg )

--- a/src/bvh/collision_object/impl.hpp
+++ b/src/bvh/collision_object/impl.hpp
@@ -177,6 +177,7 @@ namespace bvh
 
     // Split and clustering views
     view< bvh::entity_snapshot * > snapshots;
+    host_view< bvh::entity_snapshot * > snapshots_h;
     view< std::size_t * > split_indices;  ///< Mapping from original element indices to the reordered indices
     view< std::size_t * > splits; ///< bounds of each split
     host_view< std::size_t * > splits_h;

--- a/src/bvh/collision_object/impl.hpp
+++ b/src/bvh/collision_object/impl.hpp
@@ -113,7 +113,7 @@ namespace bvh
       {
         debug_assert( offset < send_msg->data_size, "split index offset={} is out of bounds (local data size is {})", offset, send_msg->data_size );
         debug_assert( split_indices_h( j ) < snapshots.extent( 0 ), "user index is out of bounds" );
-        // use subviews, deep_copy to host
+        // FIXME_CUDA: use subviews, deep_copy to host
         std::memcpy( &send_msg->user_data()[offset], m_entity_ptr + (split_indices_h( j ) * m_entity_unit_size), m_entity_unit_size);
         offset += m_entity_unit_size;
       }

--- a/src/bvh/collision_object/impl.hpp
+++ b/src/bvh/collision_object/impl.hpp
@@ -59,7 +59,8 @@ namespace bvh
       _patch->ghost_destinations.clear();
       _patch->patch_meta = _msg->patch_meta;
       Kokkos::resize( Kokkos::WithoutInitializing, _patch->bytes, _msg->data_size );
-      std::memcpy( _patch->bytes.data(), _msg->user_data(), _msg->data_size );
+      bvh::unmanaged_host_view< unsigned char * > u_data( _msg->user_data(), _msg->data_size );
+      Kokkos::deep_copy( _patch->bytes, u_data );
       _patch->origin_node = _msg->origin_node;
     }
   }

--- a/src/bvh/collision_object/impl.hpp
+++ b/src/bvh/collision_object/impl.hpp
@@ -57,7 +57,7 @@ namespace bvh
       logger.debug( "late initializing narrowphase patch {} with {} bytes", idx.x(), _msg->data_size );
       _patch->ghost_destinations.clear();
       _patch->patch_meta = _msg->patch_meta;
-      _patch->bytes.resize(_msg->data_size);
+      Kokkos::resize( _patch->bytes, _msg->data_size );
       std::memcpy( _patch->bytes.data(), _msg->user_data(), _msg->data_size );
       _patch->origin_node = _msg->origin_node;
     }
@@ -169,7 +169,7 @@ namespace bvh
     struct narrowphase_patch_cache_entry
     {
       patch<> meta;
-      std::vector< unsigned char > patch_data;
+      view< unsigned char * > patch_data;
       ::vt::NodeType origin_node;
     };
 

--- a/src/bvh/collision_object/impl.hpp
+++ b/src/bvh/collision_object/impl.hpp
@@ -163,7 +163,7 @@ namespace bvh
     std::vector< collision_object_impl::narrowphase_index > active_narrowphase_indices;
     std::unordered_set< size_t > active_narrowphase_local_index;
 
-    bvh::view< const unsigned char * > m_entity_ptr;
+    bvh::view< const std::byte * > m_entity_ptr;
     std::size_t m_entity_unit_size = 0;
     element_permutations m_latest_permutations;
 

--- a/src/bvh/collision_object/impl.hpp
+++ b/src/bvh/collision_object/impl.hpp
@@ -113,6 +113,7 @@ namespace bvh
       {
         debug_assert( offset < send_msg->data_size, "split index offset={} is out of bounds (local data size is {})", offset, send_msg->data_size );
         debug_assert( split_indices_h( j ) < snapshots.extent( 0 ), "user index is out of bounds" );
+        // use subviews, deep_copy to host
         std::memcpy( &send_msg->user_data()[offset], m_entity_ptr + (split_indices_h( j ) * m_entity_unit_size), m_entity_unit_size);
         offset += m_entity_unit_size;
       }

--- a/src/bvh/collision_object/impl.hpp
+++ b/src/bvh/collision_object/impl.hpp
@@ -96,7 +96,7 @@ namespace bvh
 
       const auto idx = _local_idx;
       const auto sbeg = ( idx == 0 ) ? 0 : splits_h( idx - 1 );
-      const auto send = ( idx == num_splits ) ? split_indices_h.extent( 0 ) : splits_h( idx );
+      const auto send = ( idx == num_splits ) ? split_indices.extent( 0 ) : splits_h( idx );
       const std::size_t nelements = send - sbeg;
       const std::size_t chunk_data_size = nelements * m_entity_unit_size;
       const int rank = _rank;
@@ -112,9 +112,9 @@ namespace bvh
       for (std::size_t j = sbeg; j < send; ++j)
       {
         debug_assert( offset < send_msg->data_size, "split index offset={} is out of bounds (local data size is {})", offset, send_msg->data_size );
-        debug_assert( split_indices_h( j ) < snapshots.extent( 0 ), "user index is out of bounds" );
+        debug_assert( split_indices( j ) < snapshots.extent( 0 ), "user index is out of bounds" );
         // FIXME_CUDA: use subviews, deep_copy to host
-        std::memcpy( &send_msg->user_data()[offset], m_entity_ptr + (split_indices_h( j ) * m_entity_unit_size), m_entity_unit_size);
+        std::memcpy( &send_msg->user_data()[offset], m_entity_ptr + (split_indices( j ) * m_entity_unit_size), m_entity_unit_size);
         offset += m_entity_unit_size;
       }
 
@@ -179,7 +179,6 @@ namespace bvh
     view< bvh::entity_snapshot * > snapshots;
     view< std::size_t * > split_indices;  ///< Mapping from original element indices to the reordered indices
     view< std::size_t * > splits; ///< bounds of each split
-    host_view< std::size_t * > split_indices_h;
     host_view< std::size_t * > splits_h;
     std::size_t num_splits = 0; ///< The number of actual splits -- may be les than splits.extent( 0 )
 

--- a/src/bvh/collision_object/impl.hpp
+++ b/src/bvh/collision_object/impl.hpp
@@ -114,7 +114,8 @@ namespace bvh
         debug_assert( offset < send_msg->data_size, "split index offset={} is out of bounds (local data size is {})", offset, send_msg->data_size );
         debug_assert( split_indices( j ) < snapshots.extent( 0 ), "user index is out of bounds" );
         // FIXME_CUDA: use subviews, deep_copy to host
-        std::memcpy( &send_msg->user_data()[offset], m_entity_ptr + (split_indices( j ) * m_entity_unit_size), m_entity_unit_size);
+        std::memcpy( &send_msg->user_data()[offset], m_entity_ptr.data() + ( split_indices( j ) * m_entity_unit_size ),
+                     m_entity_unit_size );
         offset += m_entity_unit_size;
       }
 
@@ -162,7 +163,7 @@ namespace bvh
     std::vector< collision_object_impl::narrowphase_index > active_narrowphase_indices;
     std::unordered_set< size_t > active_narrowphase_local_index;
 
-    const unsigned char *m_entity_ptr;
+    bvh::view< const unsigned char * > m_entity_ptr;
     std::size_t m_entity_unit_size = 0;
     element_permutations m_latest_permutations;
 

--- a/src/bvh/collision_object/impl.hpp
+++ b/src/bvh/collision_object/impl.hpp
@@ -118,7 +118,7 @@ namespace bvh
         debug_assert( offset < send_msg->data_size, "split index offset={} is out of bounds (local data size is {})", offset, send_msg->data_size );
         debug_assert( split_indices_h( j ) < snapshots.extent( 0 ), "user index is out of bounds" );
         // FIXME_CUDA: use subviews, deep_copy to host
-        auto src = Kokkos::subview( m_entity_ptr, std::pair{ split_indices_h( j ) * m_entity_unit_size, m_entity_unit_size } );
+        auto src = Kokkos::subview( m_entity_ptr, std::pair{ split_indices_h( j ) * m_entity_unit_size, ( split_indices_h( j ) + 1 ) * m_entity_unit_size } );
         auto dest = Kokkos::subview( user_data, std::pair{ offset, offset + m_entity_unit_size } );
         Kokkos::deep_copy( dest, src );
         //std::memcpy( &send_msg->user_data()[offset], m_entity_ptr.data() + ( split_indices_h( j ) * m_entity_unit_size ),

--- a/src/bvh/collision_object/impl.hpp
+++ b/src/bvh/collision_object/impl.hpp
@@ -57,7 +57,7 @@ namespace bvh
       logger.debug( "late initializing narrowphase patch {} with {} bytes", idx.x(), _msg->data_size );
       _patch->ghost_destinations.clear();
       _patch->patch_meta = _msg->patch_meta;
-      Kokkos::resize( _patch->bytes, _msg->data_size );
+      Kokkos::resize( Kokkos::WithoutInitializing, _patch->bytes, _msg->data_size );
       std::memcpy( _patch->bytes.data(), _msg->user_data(), _msg->data_size );
       _patch->origin_node = _msg->origin_node;
     }

--- a/src/bvh/collision_object/impl.hpp
+++ b/src/bvh/collision_object/impl.hpp
@@ -110,8 +110,8 @@ namespace bvh
 
       logger.debug( "obj={} sending narrowphase patch {} with {} num elements",
                     collision_idx, vt_index{ _local_idx + rank * overdecomposition }, nelements );
-      
-      
+
+
       m_user_data->scatter_to_byte_buffer( send_msg->user_data(), sbeg, send, split_indices_h );
 
       send_msg->origin_node = rank;
@@ -133,7 +133,7 @@ namespace bvh
     std::vector< std::size_t > local_data_indices;
 
     // Not a collection because we want this to always live on a per-node basis
-    std::vector< narrowphase_result > local_results;
+    narrowphase_result local_results;
 
     ::vt::messaging::CollectionChainSet< vt_index > chainset;
     std::size_t overdecomposition = 1;

--- a/src/bvh/collision_object/impl.hpp
+++ b/src/bvh/collision_object/impl.hpp
@@ -61,7 +61,6 @@ namespace bvh
       _patch->patch_meta = _msg->patch_meta;
       Kokkos::resize( Kokkos::WithoutInitializing, _patch->bytes, _msg->data_size );
       Kokkos::deep_copy( _patch->bytes, _msg->user_data() );
-      //std::memcpy( _patch->bytes.data(), _msg->user_data(), _msg->data_size );
       _patch->origin_node = _msg->origin_node;
     }
   }
@@ -110,7 +109,6 @@ namespace bvh
 
       logger.debug( "obj={} sending narrowphase patch {} with {} num elements",
                     collision_idx, vt_index{ _local_idx + rank * overdecomposition }, nelements );
-
 
       m_user_data->scatter_to_byte_buffer( send_msg->user_data(), sbeg, send, split_indices_h );
 

--- a/src/bvh/collision_object/narrowphase.cpp
+++ b/src/bvh/collision_object/narrowphase.cpp
@@ -67,7 +67,8 @@ namespace bvh
         _patch->ghost_destinations.clear();
         _patch->patch_meta = _msg->patch_meta;
         Kokkos::resize( Kokkos::WithoutInitializing, _patch->bytes, _msg->data_size );
-        std::memcpy( _patch->bytes.data(), _msg->user_data(), _msg->data_size );
+        Kokkos::deep_copy( _patch->bytes, _msg->user_data() );
+        //std::memcpy( _patch->bytes.data(), _msg->user_data(), _msg->data_size );
         _patch->origin_node = _msg->origin_node;
       }
     } // namespace details

--- a/src/bvh/collision_object/narrowphase.cpp
+++ b/src/bvh/collision_object/narrowphase.cpp
@@ -33,7 +33,6 @@
 #include "narrowphase.hpp"
 #include "../collision_object.hpp"
 #include "impl.hpp"
-#include "../debug/assert.hpp"
 
 #include <vt/trace/trace_user.h>
 

--- a/src/bvh/collision_object/narrowphase.cpp
+++ b/src/bvh/collision_object/narrowphase.cpp
@@ -66,7 +66,7 @@ namespace bvh
       {
         _patch->ghost_destinations.clear();
         _patch->patch_meta = _msg->patch_meta;
-        _patch->bytes.resize(_msg->data_size);
+        Kokkos::resize( _patch->bytes, _msg->data_size );
         std::memcpy( _patch->bytes.data(), _msg->user_data(), _msg->data_size );
         _patch->origin_node = _msg->origin_node;
       }

--- a/src/bvh/collision_object/narrowphase.cpp
+++ b/src/bvh/collision_object/narrowphase.cpp
@@ -66,7 +66,7 @@ namespace bvh
       {
         _patch->ghost_destinations.clear();
         _patch->patch_meta = _msg->patch_meta;
-        Kokkos::resize( _patch->bytes, _msg->data_size );
+        Kokkos::resize( Kokkos::WithoutInitializing, _patch->bytes, _msg->data_size );
         std::memcpy( _patch->bytes.data(), _msg->user_data(), _msg->data_size );
         _patch->origin_node = _msg->origin_node;
       }

--- a/src/bvh/collision_object/narrowphase.cpp
+++ b/src/bvh/collision_object/narrowphase.cpp
@@ -68,7 +68,6 @@ namespace bvh
         _patch->patch_meta = _msg->patch_meta;
         Kokkos::resize( Kokkos::WithoutInitializing, _patch->bytes, _msg->data_size );
         Kokkos::deep_copy( _patch->bytes, _msg->user_data() );
-        //std::memcpy( _patch->bytes.data(), _msg->user_data(), _msg->data_size );
         _patch->origin_node = _msg->origin_node;
       }
     } // namespace details

--- a/src/bvh/collision_object/top_down.cpp
+++ b/src/bvh/collision_object/top_down.cpp
@@ -94,8 +94,7 @@ namespace bvh
         reduce_vec m_snapshots;
       };
 
-
-      BVH_HOST_DEVICE void set_broadphase_trees( collision_object *_coll_obj, broadphase_tree_msg *_msg )
+      void set_broadphase_trees( collision_object *_coll_obj, broadphase_tree_msg *_msg )
       {
         _coll_obj->get_impl().tree = _msg->tree;
       }

--- a/src/bvh/collision_object/types.hpp
+++ b/src/bvh/collision_object/types.hpp
@@ -123,6 +123,7 @@ namespace bvh
         if ( _s.isUnpacking() )
         {
           std::size_t stride;
+          // FIXME_CUDA: replace vector with a View
           std::vector< unsigned char > bbuffer;
 
           _s | stride | bbuffer;
@@ -131,7 +132,8 @@ namespace bvh
           result.set_data( bbuffer.data(), bbuffer.size() / stride );
         } else {
           auto stride = result.stride();
-          std::vector< unsigned char > bbuffer = result.byte_buffer();
+          // FIXME_CUDA: replace vector with a View
+          auto bbuffer = result.byte_buffer();
           _s | stride | bbuffer;
         }
       }

--- a/src/bvh/collision_object/types.hpp
+++ b/src/bvh/collision_object/types.hpp
@@ -193,7 +193,7 @@ namespace bvh
       {}
 
       patch<> patch_meta;
-      std::vector< unsigned char > bytes;
+      view< unsigned char * > bytes;
       ::vt::NodeType origin_node = ::vt::uninitialized_destination;
       std::unordered_set< ::vt::NodeType > ghost_destinations;
       collision_object_proxy_type collision_object;
@@ -281,7 +281,7 @@ namespace bvh
       vt_msg_serialize_required();
 
       patch<> meta;
-      std::vector< unsigned char > patch_data;
+      view< unsigned char * > patch_data;
       ::vt::NodeType origin_node;
       vt_index idx;
 

--- a/src/bvh/collision_object/types.hpp
+++ b/src/bvh/collision_object/types.hpp
@@ -123,16 +123,18 @@ namespace bvh
         if ( _s.isUnpacking() )
         {
           std::size_t stride;
+          std::size_t num_elements;
           view< std::byte * > bbuffer;
 
-          _s | stride | bbuffer;
+          _s | stride | num_elements | bbuffer;
 
-          result = narrowphase_result( stride, bbuffer.extent( 0 ) / stride );
-          result.set_data( bbuffer.data(), bbuffer.extent( 0 ) / stride );
+          result = narrowphase_result( stride, num_elements );
+          result.set_data( bbuffer.data(), num_elements );
         } else {
           auto stride = result.stride();
+          auto num_elements = result.size();
           view< std::byte * > bbuffer = result.byte_buffer();
-          _s | stride | bbuffer;
+          _s | stride | num_elements | bbuffer;
         }
       }
     };

--- a/src/bvh/collision_object/types.hpp
+++ b/src/bvh/collision_object/types.hpp
@@ -123,17 +123,15 @@ namespace bvh
         if ( _s.isUnpacking() )
         {
           std::size_t stride;
-          // FIXME_CUDA: replace vector with a View (?)
-          std::vector< std::byte > bbuffer;
+          view< std::byte * > bbuffer;
 
           _s | stride | bbuffer;
 
           result = narrowphase_result( stride );
-          result.set_data( bbuffer.data(), bbuffer.size() / stride );
+          result.set_data( bbuffer.data(), bbuffer.extent( 0 ) / stride );
         } else {
           auto stride = result.stride();
-          // FIXME_CUDA: replace vector with a View (?)
-          std::vector< std::byte > bbuffer = result.byte_buffer();
+          view< std::byte * > bbuffer = result.byte_buffer();
           _s | stride | bbuffer;
         }
       }

--- a/src/bvh/collision_object/types.hpp
+++ b/src/bvh/collision_object/types.hpp
@@ -127,7 +127,7 @@ namespace bvh
 
           _s | stride | bbuffer;
 
-          result = narrowphase_result( stride, bbuffer.extent( 0 ) );
+          result = narrowphase_result( stride, bbuffer.extent( 0 ) / stride );
           result.set_data( bbuffer.data(), bbuffer.extent( 0 ) / stride );
         } else {
           auto stride = result.stride();

--- a/src/bvh/collision_object/types.hpp
+++ b/src/bvh/collision_object/types.hpp
@@ -127,7 +127,7 @@ namespace bvh
 
           _s | stride | bbuffer;
 
-          result = narrowphase_result( stride );
+          result = narrowphase_result( stride, bbuffer.extent( 0 ) );
           result.set_data( bbuffer.data(), bbuffer.extent( 0 ) / stride );
         } else {
           auto stride = result.stride();

--- a/src/bvh/collision_object/types.hpp
+++ b/src/bvh/collision_object/types.hpp
@@ -224,7 +224,7 @@ namespace bvh
         );
       }
 
-      Kokkos::View< const std::byte *, Kokkos::LayoutLeft, bvh::host_execution_space, Kokkos::MemoryTraits< Kokkos::Unmanaged > >
+      auto
       user_data() const
       {
         return Kokkos::View< const std::byte *, bvh::host_execution_space, Kokkos::MemoryTraits< Kokkos::Unmanaged > >(

--- a/src/bvh/collision_query.hpp
+++ b/src/bvh/collision_query.hpp
@@ -122,6 +122,7 @@ namespace bvh
 
   private:
 
+    // FIXME_CUDA: replace with a View (possibly strided?)
     std::vector< unsigned char > m_data;
     std::size_t m_stride;
     std::size_t m_num_elements;
@@ -224,7 +225,7 @@ namespace bvh
     using index_type = IndexType;
     using value_type = std::pair< IndexType, IndexType >;
     using container_type = std::vector< value_type >;
-    
+
     using iterator = typename container_type::iterator;
     using const_iterator = typename container_type::const_iterator;
 
@@ -233,18 +234,18 @@ namespace bvh
     collision_query_result( iterator _b, iterator _e )
       : pairs{ _b, _e }
     {}
-    
+
     typename container_type::size_type size() const noexcept
     { return pairs.size(); }
-    
+
     iterator begin() { return pairs.begin(); }
     const_iterator begin() const { return pairs.begin(); }
     const_iterator cbegin() const { return pairs.cbegin(); }
-    
+
     iterator end() { return pairs.end(); }
     const_iterator end() const { return pairs.end(); }
     const_iterator cend() const { return pairs.cend(); }
-    
+
     container_type pairs;
   };
 
@@ -260,7 +261,7 @@ namespace bvh
       results.pairs.emplace_back( _left, _right );
     }
   };
-  
+
   namespace detail
   {
     template< typename TreeType, typename ResultsType >
@@ -273,9 +274,9 @@ namespace bvh
       {
         reserve_size += pc.first.entities.size() * pc.second.entities.size();
       }
-      
+
       ret.pairs.reserve( reserve_size );
-      
+
       for ( auto &&pc : _results )
       {
         for ( auto &&entity_i : pc.first.entities )
@@ -286,10 +287,10 @@ namespace bvh
           }
         }
       }
-      
+
       return ret;
     }
-    
+
     template< typename NodeType, typename LeftLeafs, typename RightLeafs, typename OutputIterator >
     void
     get_overlapping_indices( const NodeType *_left,
@@ -301,7 +302,7 @@ namespace bvh
       // Both nodes need to exist and overlap in order to continue traversal
       if ( !_left || !_right || !overlap( _left->kdop(), _right->kdop() ) )
         return;
-      
+
       if ( _left->is_leaf() )
       {
         // Both are leaves, add all patch indices
@@ -327,7 +328,7 @@ namespace bvh
         get_overlapping_indices< NodeType >( _left->right(), _right->right(), _left_leafs, _right_leafs, _iter );
       }
     };
-  
+
     template< typename NodeType, typename Leafs, typename OutputIterator >
     void
     get_self_colliding_indices( const NodeType *_node,
@@ -336,7 +337,7 @@ namespace bvh
     {
       if ( !_node )
         return;
-    
+
       if ( _node->is_leaf() )
       {
         // Add all combinations of pairs
@@ -356,17 +357,17 @@ namespace bvh
       }
     };
   }
-  
+
   template< typename TreeType >
   typename TreeType::collision_query_result_type
   self_collision_set( const TreeType &_tree )
   {
     typename TreeType::collision_query_result_type ret;
     detail::get_self_colliding_indices< typename TreeType::node_type >( _tree.root(), _tree.leafs(), std::back_inserter( ret.pairs ) );
-    
+
     return ret;
   }
-  
+
   template< typename TreeType >
   typename TreeType::collision_query_result_type
   potential_collision_set( const TreeType &_lhs, const TreeType &_rhs )
@@ -374,14 +375,14 @@ namespace bvh
     typename TreeType::collision_query_result_type ret;
     detail::get_overlapping_indices< typename TreeType::node_type >( _lhs.root(), _rhs.root(), _lhs.leafs(), _rhs.leafs(),
       std::back_inserter( ret.pairs ) );
-    
+
     return ret;
   }
 
 #if 0
   namespace detail
   {
-    
+
     template< typename TreeType, typename OutputIterator >
     void
     get_node_overlapping_indices( const typename TreeType::kdop_type &_kdop,
@@ -392,7 +393,7 @@ namespace bvh
     {
       if ( !_node || !overlap( _kdop, _node->kdop() ) )
         return;
-      
+
       if ( _node->is_leaf() )
       {
         for ( std::size_t i = _node->get_patch()[0]; i < _node->get_patch()[1]; ++i )
@@ -404,7 +405,7 @@ namespace bvh
         get_node_overlapping_indices< TreeType, OutputIterator >( _kdop, _local_index, _node->right(), _leafs, _iter );
       }
     }
-    
+
     template< typename TreeType, typename OutputIterator >
     void
     get_tree_overlapping_indices( const typename TreeType::kdop_type &_kdop,

--- a/src/bvh/collision_query.hpp
+++ b/src/bvh/collision_query.hpp
@@ -50,17 +50,18 @@ namespace bvh
   template< typename T >
   struct broadphase_collision
   {
-    broadphase_collision(collision_object &_object,
-                         const patch<> &_meta,
-                         std::size_t _patch_id,
-                         span<const T> _elements)
-        : object(_object), meta( _meta ), patch_id(_patch_id), elements(_elements)
+    broadphase_collision( collision_object &_object, const patch<> &_meta, std::size_t _patch_id,
+                          bvh::host_view< T * > _elements )
+      : object( _object ),
+        meta( _meta ),
+        patch_id( _patch_id ),
+        elements( _elements )
     {}
 
     collision_object &object;
     patch<> meta;
     std::size_t patch_id;
-    span< const T > elements;
+    bvh::host_view< T * > elements;
   };
 
   class narrowphase_result
@@ -122,7 +123,6 @@ namespace bvh
 
   private:
 
-    // FIXME_CUDA: replace with a View (possibly strided?)
     std::vector< unsigned char > m_data;
     std::size_t m_stride;
     std::size_t m_num_elements;

--- a/src/bvh/collision_query.hpp
+++ b/src/bvh/collision_query.hpp
@@ -82,8 +82,8 @@ namespace bvh
     {
       m_num_elements += _num_elements;
       m_data.insert( m_data.end(),
-                    static_cast< unsigned char * >( _data ),
-                    static_cast< unsigned char * >( _data ) + _num_elements * m_stride );
+                    static_cast< std::byte * >( _data ),
+                    static_cast< std::byte * >( _data ) + _num_elements * m_stride );
     }
 
     void set_data( void *_data, std::size_t _num_elements )
@@ -96,7 +96,7 @@ namespace bvh
     void *allocate( std::size_t _n )
     {
       m_num_elements += _n;
-      auto iter = m_data.insert( m_data.end(), _n * m_stride, 0x00 );
+      auto iter = m_data.insert( m_data.end(), _n * m_stride, static_cast< std::byte >( 0x00 ) );
       return &( *iter );
     }
 
@@ -118,12 +118,12 @@ namespace bvh
     }
 
     std::size_t stride() const noexcept { return m_stride; }
-    const std::vector< unsigned char > &byte_buffer() const noexcept { return m_data; }
+    const std::vector< std::byte > &byte_buffer() const noexcept { return m_data; }
     std::size_t size() const noexcept { return m_num_elements; }
 
   private:
 
-    std::vector< unsigned char > m_data;
+    std::vector< std::byte > m_data;
     std::size_t m_stride;
     std::size_t m_num_elements;
   };

--- a/src/bvh/collision_query.hpp
+++ b/src/bvh/collision_query.hpp
@@ -89,7 +89,7 @@ namespace bvh
     void set_data( void *_data, std::size_t _num_elements )
     {
       auto num_bytes = _num_elements * m_stride;
-      check_capacity( num_bytes );
+      BVH_ASSERT( num_bytes <= m_data.extent( 0 ) );
       Kokkos::atomic_add( &m_num_elements(), _num_elements );
       auto new_data = view< std::byte * >( static_cast< std::byte * >( _data ), num_bytes );
       auto dst = Kokkos::subview( m_data, std::pair< std::size_t, std::size_t >( 0, num_bytes ) );
@@ -101,7 +101,7 @@ namespace bvh
       auto prev_num_elements = Kokkos::atomic_fetch_add( &m_num_elements(), _n );
       auto last_element_idx = prev_num_elements * m_stride;
       auto num_new_bytes = _n * m_stride;
-      check_capacity( last_element_idx + num_new_bytes );
+      BVH_ASSERT( last_element_idx + num_new_bytes <= m_data.extent( 0 ) );
       return static_cast< void * >( &m_data( last_element_idx ) );
     }
 
@@ -126,10 +126,6 @@ namespace bvh
       std::size_t num_elements;
       Kokkos::deep_copy( num_elements, m_num_elements );
       return num_elements;
-    }
-
-    void check_capacity( const std::size_t& requested_size ) const noexcept {
-      BVH_ASSERT( requested_size <= m_data.extent( 0 ) );
     }
 
     std::size_t m_stride;

--- a/src/bvh/collision_query.hpp
+++ b/src/bvh/collision_query.hpp
@@ -100,8 +100,7 @@ namespace bvh
     {
       auto prev_num_elements = Kokkos::atomic_fetch_add( &m_num_elements(), _n );
       auto last_element_idx = prev_num_elements * m_stride;
-      auto num_new_bytes = _n * m_stride;
-      BVH_ASSERT( last_element_idx + num_new_bytes <= m_data.extent( 0 ) );
+      BVH_ASSERT( _n * m_stride + last_element_idx <= m_data.extent( 0 ) );
       return static_cast< void * >( &m_data( last_element_idx ) );
     }
 

--- a/src/bvh/collision_query.hpp
+++ b/src/bvh/collision_query.hpp
@@ -33,6 +33,7 @@
 #ifndef INC_BVH_COLLISION_QUERY_HPP
 #define INC_BVH_COLLISION_QUERY_HPP
 
+#include <decl/Kokkos_Declare_OPENMP.hpp>
 #include <vector>
 #include <functional>
 #include <cstring>
@@ -40,7 +41,6 @@
 #include "util/span.hpp"
 #include "util/assert.hpp"
 #include "patch.hpp"
-
 #include "debug/assert.hpp"
 
 namespace bvh
@@ -54,7 +54,7 @@ namespace bvh
   struct broadphase_collision
   {
     broadphase_collision( collision_object &_object, const patch<> &_meta, std::size_t _patch_id,
-                          bvh::host_view< T * > _elements )
+                          Kokkos::View< T * > _elements )
       : object( _object ),
         meta( _meta ),
         patch_id( _patch_id ),
@@ -64,7 +64,7 @@ namespace bvh
     collision_object &object;
     patch<> meta;
     std::size_t patch_id;
-    bvh::host_view< T * > elements;
+    Kokkos::View< T * > elements;
   };
 
   class narrowphase_result
@@ -78,16 +78,22 @@ namespace bvh
         : narrowphase_result( _stride, 0 ) {}
 
     explicit narrowphase_result( std::size_t _stride, std::size_t _n_possible_elements )
-        : m_stride( _stride )
+      : m_stride( "narrowphase_result.stride" ),
+        m_data( "narrowphase_result.data", _n_possible_elements * _stride ),
+        m_num_elements( "narrowphase_result.num_elements" )
     {
-      m_num_elements = view< std::size_t >("m_num_elements");
+      Kokkos::deep_copy( m_stride, _stride );
       Kokkos::deep_copy( m_num_elements, 0 );
-      m_data = view< std::byte *>( "m_data", _n_possible_elements * m_stride );
     }
+
+    KOKKOS_DEFAULTED_FUNCTION narrowphase_result( const narrowphase_result & ) = default;
+    KOKKOS_DEFAULTED_FUNCTION narrowphase_result &operator=( const narrowphase_result & ) = default;
 
     void set_data( void *_data, std::size_t _num_elements )
     {
-      auto num_bytes = _num_elements * m_stride;
+      std::size_t stride = 0;
+      Kokkos::deep_copy( stride, m_stride );
+      auto num_bytes = _num_elements * stride;
       BVH_ASSERT( num_bytes <= m_data.extent( 0 ) );
       auto new_data = view< std::byte * >( static_cast< std::byte * >( _data ), num_bytes );
       auto dst = Kokkos::subview( m_data, std::pair< std::size_t, std::size_t >( 0, num_bytes ) );
@@ -95,30 +101,43 @@ namespace bvh
       Kokkos::atomic_add( &m_num_elements(), _num_elements );
     }
 
-    void *allocate( std::size_t _n )
+    KOKKOS_INLINE_FUNCTION void *allocate( std::size_t _n )
     {
       auto prev_num_elements = Kokkos::atomic_fetch_add( &m_num_elements(), _n );
-      auto last_element_idx = prev_num_elements * m_stride;
-      BVH_ASSERT( _n * m_stride + last_element_idx <= m_data.extent( 0 ) );
+      auto last_element_idx = prev_num_elements * m_stride();
+      BVH_ASSERT( _n * m_stride() + last_element_idx <= m_data.extent( 0 ) );
       return static_cast< void * >( &m_data( last_element_idx ) );
     }
 
-    void *at( std::size_t _i )
-    {
-      return &m_data( _i * m_stride );
-    }
-
-    const void *at( std::size_t _i ) const
-    {
-      return &m_data( _i * m_stride );
-    }
-
-    void *data() { return m_data.data(); }
-    std::size_t stride() const noexcept { return m_stride; }
+    KOKKOS_INLINE_FUNCTION void *data() { return m_data.data(); }
+    std::size_t stride() const noexcept { return get_stride(); }
     const view< std::byte * > &byte_buffer() const noexcept { return m_data; }
+
     std::size_t size() const noexcept { return get_m_num_elements(); }
 
-  private:
+    void extend( const narrowphase_result &_other )
+    {
+      const auto this_stride = stride();
+      const auto other_stride = _other.stride();
+      always_assert( this_stride == 0 || this_stride == other_stride, fmt::format( "stride {} doesn't match {}", this_stride, other_stride ) );
+      const auto this_size = size();
+      const auto other_size = _other.size();
+      const auto old_size_bytes = m_data.size();
+      Kokkos::resize( m_data, _other.m_data.size() + m_data.size() );
+      Kokkos::deep_copy(
+        Kokkos::subview( m_data, Kokkos::make_pair( old_size_bytes, m_data.size() ) ),
+        _other.m_data );
+      Kokkos::deep_copy( m_num_elements, this_size + other_size );
+      if ( this_stride == 0 )
+        Kokkos::deep_copy( m_stride, other_stride );
+    }
+
+    void clear()
+    {
+      Kokkos::deep_copy( m_num_elements, 0 );
+    }
+
+  protected:
 
     std::size_t get_m_num_elements() const noexcept {
       std::size_t num_elements;
@@ -126,36 +145,61 @@ namespace bvh
       return num_elements;
     }
 
-    std::size_t m_stride;
+    std::size_t get_stride() const noexcept {
+      std::size_t stride;
+      Kokkos::deep_copy( stride, m_stride );
+      return stride;
+    }
+
+    view< std::size_t > m_stride;
     view< std::byte * > m_data;
     view< std::size_t > m_num_elements;
   };
 
   template< typename T >
-  class typed_narrowphase_result : public narrowphase_result
+  class typed_narrowphase_result : private narrowphase_result
   {
   public:
 
     explicit typed_narrowphase_result()
-        : narrowphase_result( sizeof( T ) )
+        : narrowphase_result( sizeof( T ) ), m_typed_view( reinterpret_cast< T * >( m_data.data() ), size() )
     {
     }
 
+    explicit typed_narrowphase_result( const narrowphase_result &_other )
+      : narrowphase_result( _other ), m_typed_view( reinterpret_cast< T * >( m_data.data() ), size() )
+    {}
+
+    explicit typed_narrowphase_result( std::size_t _size )
+      : narrowphase_result( sizeof( T ), _size ), m_typed_view( reinterpret_cast< T * >( m_data.data() ), size() )
+    {}
+
     template< typename... Args >
+    KOKKOS_INLINE_FUNCTION
     T &emplace_back( Args &&... _args )
     {
       return *( new ( allocate( 1 ) ) T( std::forward< Args >( _args )... ) );
     }
 
+    KOKKOS_INLINE_FUNCTION
     T &operator[]( std::size_t _i )
     {
-      return *static_cast< T * >( at( _i ) );
+      return m_typed_view[_i];
     }
 
+    KOKKOS_INLINE_FUNCTION
     const T &operator[]( std::size_t _i ) const
     {
-      return *static_cast< const T * >( at( _i ) );
+      return m_typed_view[_i];
     }
+
+    std::size_t size() const noexcept { return narrowphase_result::size(); }
+
+    Kokkos::View< T *, Kokkos::MemoryUnmanaged > elements() const noexcept { return m_typed_view; }
+
+  private:
+
+    Kokkos::View< T *, Kokkos::MemoryUnmanaged > m_typed_view;
   };
 
   struct narrowphase_result_pair

--- a/src/bvh/collision_query.hpp
+++ b/src/bvh/collision_query.hpp
@@ -93,17 +93,16 @@ namespace bvh
     {
       std::size_t stride = 0;
       Kokkos::deep_copy( stride, m_stride );
-      auto num_bytes = _num_elements * stride;
-      BVH_ASSERT( num_bytes <= m_data.extent( 0 ) );
+      const auto num_bytes = _num_elements * stride;
       auto new_data = view< std::byte * >( static_cast< std::byte * >( _data ), num_bytes );
+
+      // Resize only if we need to grow
+      if ( m_data.extent( 0 ) < num_bytes )
+        Kokkos::resize( m_data, num_bytes );
+
       auto dst = Kokkos::subview( m_data, std::pair< std::size_t, std::size_t >( 0, num_bytes ) );
       Kokkos::deep_copy( dst, new_data );
-
-      // On host so we assume this does not need to be done atomically
-      std::size_t nelements = 0;
-      Kokkos::deep_copy( nelements, m_num_elements );
-      nelements += _num_elements;
-      Kokkos::deep_copy( m_num_elements, nelements );
+      Kokkos::deep_copy( m_num_elements, _num_elements );
     }
 
     KOKKOS_INLINE_FUNCTION void *allocate( std::size_t _n )

--- a/src/bvh/collision_query.hpp
+++ b/src/bvh/collision_query.hpp
@@ -98,7 +98,12 @@ namespace bvh
       auto new_data = view< std::byte * >( static_cast< std::byte * >( _data ), num_bytes );
       auto dst = Kokkos::subview( m_data, std::pair< std::size_t, std::size_t >( 0, num_bytes ) );
       Kokkos::deep_copy( dst, new_data );
-      Kokkos::atomic_add( &m_num_elements(), _num_elements );
+
+      // On host so we assume this does not need to be done atomically
+      std::size_t nelements = 0;
+      Kokkos::deep_copy( nelements, m_num_elements );
+      nelements += _num_elements;
+      Kokkos::deep_copy( m_num_elements, nelements );
     }
 
     KOKKOS_INLINE_FUNCTION void *allocate( std::size_t _n )
@@ -115,6 +120,13 @@ namespace bvh
 
     std::size_t size() const noexcept { return get_m_num_elements(); }
 
+    auto get_bounded_view() const noexcept
+    {
+      const size_t this_stride = stride();
+      const size_t this_size = size();
+      return Kokkos::subview( m_data, Kokkos::make_pair( size_t(0), this_stride * this_size ) );
+    }
+
     void extend( const narrowphase_result &_other )
     {
       const auto this_stride = stride();
@@ -122,11 +134,12 @@ namespace bvh
       always_assert( this_stride == 0 || this_stride == other_stride, fmt::format( "stride {} doesn't match {}", this_stride, other_stride ) );
       const auto this_size = size();
       const auto other_size = _other.size();
-      const auto old_size_bytes = m_data.size();
-      Kokkos::resize( m_data, _other.m_data.size() + m_data.size() );
+      const auto old_size_bytes = this_size * other_stride;
+      const auto new_size_bytes = ( this_size + other_size ) * other_stride;
+      Kokkos::resize( m_data, new_size_bytes );
       Kokkos::deep_copy(
         Kokkos::subview( m_data, Kokkos::make_pair( old_size_bytes, m_data.size() ) ),
-        _other.m_data );
+        _other.get_bounded_view() );
       Kokkos::deep_copy( m_num_elements, this_size + other_size );
       if ( this_stride == 0 )
         Kokkos::deep_copy( m_stride, other_stride );

--- a/src/bvh/collision_world.hpp
+++ b/src/bvh/collision_world.hpp
@@ -76,9 +76,9 @@ namespace bvh
     void set_narrowphase_functor( narrowphase_functor< T > _fun )
     {
       set_narrowphase_functor_impl( [_fun]( collision_object &_first, const patch<> &_ma, std::size_t _first_patch_id,
-                                            bvh::view< unsigned char * > _first_patch, collision_object &_second,
+                                            bvh::view< std::byte * > _first_patch, collision_object &_second,
                                             const patch<> &_mb, std::size_t _second_patch_id,
-                                            bvh::view< unsigned char * > _second_patch ) {
+                                            bvh::view< std::byte * > _second_patch ) {
         bvh::unmanaged_view< T * > u_first_elms( reinterpret_cast< T * >( _first_patch.data() ),
                                                  _first_patch.size() / sizeof( T ) );
         bvh::host_view< T * > first_elms( "first_elements", u_first_elms.size() );
@@ -113,8 +113,8 @@ namespace bvh
     friend impl &get_impl( collision_world &_world );
 
     using internal_narrowphase_functor = std::function< narrowphase_result_pair(
-      collision_object &, const patch<> &, std::size_t, bvh::view< unsigned char * >, collision_object &,
-      const patch<> &, std::size_t, bvh::view< unsigned char * > ) >;
+      collision_object &, const patch<> &, std::size_t, bvh::view< std::byte * >, collision_object &,
+      const patch<> &, std::size_t, bvh::view< std::byte * > ) >;
     void set_narrowphase_functor_impl( internal_narrowphase_functor &&_fun );
 
     std::unique_ptr< impl > m_impl;

--- a/src/bvh/collision_world.hpp
+++ b/src/bvh/collision_world.hpp
@@ -75,6 +75,8 @@ namespace bvh
     template< typename T >
     void set_narrowphase_functor( narrowphase_functor< T > _fun )
     {
+      // FIXME_CUDA: static casts from const void * need to be changed into the correct view type with element type T
+      //             (do the `internal_narrowphase_functor` change first)
       set_narrowphase_functor_impl( [_fun]( collision_object &_first, const patch<> &_ma, std::size_t _first_patch_id, const void *_first_patch, std::size_t _first_patch_size,
                                            collision_object &_second, const patch<> &_mb,  std::size_t _second_patch_id, const void *_second_patch, std::size_t _second_patch_size ) {
         const T *first_elms = static_cast< const T * >( _first_patch );
@@ -106,6 +108,7 @@ namespace bvh
 
     friend impl &get_impl( collision_world &_world );
 
+    // FIXME_CUDA: replace void* with a View
     using internal_narrowphase_functor
         = std::function< narrowphase_result_pair( collision_object &, const patch<> &, std::size_t, const void *, std::size_t, collision_object &, const patch<> &, std::size_t, const void *, std::size_t ) >;
     void set_narrowphase_functor_impl( internal_narrowphase_functor &&_fun );

--- a/src/bvh/collision_world.hpp
+++ b/src/bvh/collision_world.hpp
@@ -81,19 +81,15 @@ namespace bvh
                                             bvh::view< std::byte * > _second_patch ) {
         bvh::unmanaged_view< T * > u_first_elms( reinterpret_cast< T * >( _first_patch.data() ),
                                                  _first_patch.size() / sizeof( T ) );
-        bvh::host_view< T * > first_elms( "first_elements", u_first_elms.size() );
-        Kokkos::deep_copy( first_elms, u_first_elms );
 
         bvh::unmanaged_view< T * > u_second_elms( reinterpret_cast< T * >( _second_patch.data() ),
                                                   _second_patch.size() / sizeof( T ) );
-        bvh::host_view< T * > second_elms( "second_elements", u_second_elms.size() );
-        Kokkos::deep_copy( second_elms, u_second_elms );
 
-        assert( _first_patch_id == _ma.global_id() );
-        assert( _second_patch_id == _mb.global_id() );
+        BVH_ASSERT( _first_patch_id == _ma.global_id() );
+        BVH_ASSERT( _second_patch_id == _mb.global_id() );
 
-        broadphase_collision< T > first{ _first, _ma, _first_patch_id, first_elms };
-        broadphase_collision< T > second{ _second, _mb, _second_patch_id, second_elms };
+        broadphase_collision< T > first{ _first, _ma, _first_patch_id, u_first_elms };
+        broadphase_collision< T > second{ _second, _mb, _second_patch_id, u_second_elms };
 
         return _fun( first, second );
       } );

--- a/src/bvh/contact_entity.hpp
+++ b/src/bvh/contact_entity.hpp
@@ -140,7 +140,9 @@ namespace bvh
     Kokkos::parallel_reduce( "compute_bounds_min_diag", _elements.extent( 0 ),
                              detail::min_diag_bounds_union< Entity >{ _elements },
                              _bounds );
-    ::bvh::vt::debug( "bounds: inc_diag {}, min {}\n", _bounds().inv_diag, _bounds().min );
+    if (_bounds.is_hostspace)
+      ::bvh::vt::debug( "bounds: inc_diag {}, min {}\n",
+                        _bounds().inv_diag, _bounds().min );
     Kokkos::parallel_for( 1, KOKKOS_LAMBDA( int ) {
       auto width = _bounds().inv_diag - _bounds().min;
       _bounds().inv_diag = 1.0 / width;

--- a/src/bvh/contact_entity.hpp
+++ b/src/bvh/contact_entity.hpp
@@ -103,11 +103,8 @@ namespace bvh
     };
 
     template< typename Entity, typename T >
-    KOKKOS_INLINE_FUNCTION
-    void
-    morton_impl( view< const Entity * > _elements,
-                 single_view< min_inv_diag_bounds > _bounds,
-                 view< T * > _out_codes )
+    void morton_impl( view< const Entity * > _elements, single_view< min_inv_diag_bounds > _bounds,
+                      view< T * > _out_codes )
     {
       using traits_type = element_traits< Entity >;
       Kokkos::parallel_for( _elements.extent( 0 ), KOKKOS_LAMBDA( int _i ){

--- a/src/bvh/contact_entity.hpp
+++ b/src/bvh/contact_entity.hpp
@@ -62,9 +62,7 @@ namespace bvh
       using size_type = typename view< const Entity * >::size_type;
       using traits_type = element_traits< Entity >;
 
-      KOKKOS_INLINE_FUNCTION explicit min_diag_bounds_union( const view< const Entity * > &_v )
-        : entities( _v )
-      {}
+      KOKKOS_INLINE_FUNCTION explicit min_diag_bounds_union( const view< const Entity * > &_v ) : entities( _v ) {}
 
       KOKKOS_INLINE_FUNCTION
       void
@@ -136,8 +134,7 @@ namespace bvh
                        single_view< min_inv_diag_bounds > _bounds )
   {
     Kokkos::parallel_reduce( "compute_bounds_min_diag", _elements.extent( 0 ),
-                             detail::min_diag_bounds_union< Entity >{ _elements },
-                             _bounds );
+                             detail::min_diag_bounds_union< Entity >{ _elements }, _bounds );
     Kokkos::parallel_for( 1, KOKKOS_LAMBDA( int ) {
       auto width = _bounds().inv_diag - _bounds().min;
       _bounds().inv_diag = 1.0 / width;

--- a/src/bvh/hash.hpp
+++ b/src/bvh/hash.hpp
@@ -57,7 +57,7 @@ namespace bvh
       return _num;
     }
 
-    inline std::uint32_t expand32_alt( std::uint32_t _num )
+    KOKKOS_INLINE_FUNCTION std::uint32_t expand32_alt( std::uint32_t _num )
     {
       _num = ( _num ^ ( _num << 16 ) ) & 0xff0000ff;
       _num = ( _num ^ ( _num << 8  ) ) & 0x0300f00f;
@@ -69,7 +69,7 @@ namespace bvh
 
 
 
-    inline std::uint64_t expand64( std::uint64_t _21bit )
+    KOKKOS_INLINE_FUNCTION std::uint64_t expand64( std::uint64_t _21bit )
     {
       _21bit = ( _21bit * 0x1000001u ) & 0xfff000000fffu;
       _21bit = ( _21bit * 0x1001u ) & 0xfc003f000fc003fu;
@@ -81,7 +81,7 @@ namespace bvh
     }
 
 #ifdef __BMI2__
-    inline std::uint64_t expand64intrin( std::uint64_t _21bit )
+    KOKKOS_INLINE_FUNCTION std::uint64_t expand64intrin( std::uint64_t _21bit )
     {
 #if defined(KOKKOS_COMPILER_NVCC)
       return expand64(_21bit);
@@ -90,14 +90,14 @@ namespace bvh
 #endif
     }
 
-    inline std::uint64_t morton64_intrin( std::uint64_t _x21, std::uint64_t _y21, std::uint64_t _z21 )
+    KOKKOS_INLINE_FUNCTION std::uint64_t morton64_intrin( std::uint64_t _x21, std::uint64_t _y21, std::uint64_t _z21 )
     {
       return ( expand64intrin( _z21 ) << 2u ) | ( expand64intrin( _y21 ) << 1u ) | expand64intrin( _x21 );
     }
 #endif
 
 
-    inline std::uint64_t morton64( std::uint64_t _x21, std::uint64_t _y21, std::uint64_t _z21 )
+    KOKKOS_INLINE_FUNCTION std::uint64_t morton64( std::uint64_t _x21, std::uint64_t _y21, std::uint64_t _z21 )
     {
       return ( expand64( _z21 ) << 2u ) | ( expand64( _y21 ) << 1u ) | expand64( _x21 );
     }
@@ -144,7 +144,7 @@ namespace bvh
    * @return a vector of 10 bit quantized values
    */
   template< typename T >
-  m::vec3< std::uint32_t >
+  KOKKOS_INLINE_FUNCTION m::vec3< std::uint32_t >
   quantize32( const m::vec3< T > &_p )
   {
     // Scale up to highest 10 bit value
@@ -156,7 +156,7 @@ namespace bvh
   }
 
   template< typename T >
-  m::vec3< std::uint32_t >
+  KOKKOS_INLINE_FUNCTION m::vec3< std::uint32_t >
   quantize32( const m::vec3< T > &_p, const m::vec3< T > &_min, const m::vec3< T > &_inv_diagonal )
   {
     // Normalize
@@ -175,7 +175,7 @@ namespace bvh
    * @return a vector of 21 bit quantized values
    */
   template< typename T >
-  m::vec3< std::uint64_t >
+  KOKKOS_INLINE_FUNCTION m::vec3< std::uint64_t >
   quantize64( const m::vec3< T > &_p )
   {
     // Scale up to highest 21 bit value
@@ -187,7 +187,7 @@ namespace bvh
   }
 
   template< typename T >
-  m::vec3< std::uint64_t >
+  KOKKOS_INLINE_FUNCTION m::vec3< std::uint64_t >
   quantize64( const m::vec3< T > &_p, const m::vec3< T > &_min, const m::vec3< T > &_inv_diagonal )
   {
     // Normalize
@@ -206,7 +206,7 @@ namespace bvh
     struct quantize_impl< std::uint32_t >
     {
       template< typename... Args >
-      static auto quantize( Args &&... _args )
+      static KOKKOS_INLINE_FUNCTION auto quantize( Args &&... _args )
       {
         return quantize32( std::forward< Args >( _args )... );
       }
@@ -216,7 +216,7 @@ namespace bvh
     struct quantize_impl< std::uint64_t >
     {
       template< typename... Args >
-      static auto quantize( Args &&... _args )
+      static KOKKOS_INLINE_FUNCTION auto quantize( Args &&... _args )
       {
         return quantize64( std::forward< Args >( _args )... );
       }
@@ -224,7 +224,8 @@ namespace bvh
   }
 
   template< typename B, typename T >
-  auto quantize( const m::vec3< T > &_p, const m::vec3< T > &_min, const m::vec3< T > &_inv_diagonal )
+  KOKKOS_INLINE_FUNCTION auto
+  quantize( const m::vec3< T > &_p, const m::vec3< T > &_min, const m::vec3< T > &_inv_diagonal )
   {
     return detail::quantize_impl< B >::quantize( _p, _min, _inv_diagonal );
   }

--- a/src/bvh/hash.hpp
+++ b/src/bvh/hash.hpp
@@ -47,7 +47,7 @@ namespace bvh
 {
   namespace detail
   {
-    inline std::uint32_t expand32( std::uint32_t _num )
+    KOKKOS_INLINE_FUNCTION std::uint32_t expand32( std::uint32_t _num )
     {
       _num = ( _num * 0x00010001u ) & 0xff0000ffu;
       _num = ( _num * 0x00000101u ) & 0x0f00f00fu;

--- a/src/bvh/hash.hpp
+++ b/src/bvh/hash.hpp
@@ -67,8 +67,6 @@ namespace bvh
       return _num;
     }
 
-
-
     KOKKOS_INLINE_FUNCTION std::uint64_t expand64( std::uint64_t _21bit )
     {
       _21bit = ( _21bit * 0x1000001u ) & 0xfff000000fffu;
@@ -95,7 +93,6 @@ namespace bvh
       return ( expand64intrin( _z21 ) << 2u ) | ( expand64intrin( _y21 ) << 1u ) | expand64intrin( _x21 );
     }
 #endif
-
 
     KOKKOS_INLINE_FUNCTION std::uint64_t morton64( std::uint64_t _x21, std::uint64_t _y21, std::uint64_t _z21 )
     {
@@ -143,9 +140,7 @@ namespace bvh
    * @param _p the point to quantize with components in [0,1)
    * @return a vector of 10 bit quantized values
    */
-  template< typename T >
-  KOKKOS_INLINE_FUNCTION m::vec3< std::uint32_t >
-  quantize32( const m::vec3< T > &_p )
+  template< typename T > KOKKOS_INLINE_FUNCTION m::vec3< std::uint32_t > quantize32( const m::vec3< T > &_p )
   {
     // Scale up to highest 10 bit value
     auto scaled = _p * T{ 1024 };
@@ -156,8 +151,8 @@ namespace bvh
   }
 
   template< typename T >
-  KOKKOS_INLINE_FUNCTION m::vec3< std::uint32_t >
-  quantize32( const m::vec3< T > &_p, const m::vec3< T > &_min, const m::vec3< T > &_inv_diagonal )
+  KOKKOS_INLINE_FUNCTION m::vec3< std::uint32_t > quantize32( const m::vec3< T > &_p, const m::vec3< T > &_min,
+                                                              const m::vec3< T > &_inv_diagonal )
   {
     // Normalize
     auto norm = ( _p - _min ) * _inv_diagonal;
@@ -174,9 +169,7 @@ namespace bvh
    * @param _p the point to quantize with components in [0,1)
    * @return a vector of 21 bit quantized values
    */
-  template< typename T >
-  KOKKOS_INLINE_FUNCTION m::vec3< std::uint64_t >
-  quantize64( const m::vec3< T > &_p )
+  template< typename T > KOKKOS_INLINE_FUNCTION m::vec3< std::uint64_t > quantize64( const m::vec3< T > &_p )
   {
     // Scale up to highest 21 bit value
     auto scaled = _p * T{ 2097152 };
@@ -187,8 +180,8 @@ namespace bvh
   }
 
   template< typename T >
-  KOKKOS_INLINE_FUNCTION m::vec3< std::uint64_t >
-  quantize64( const m::vec3< T > &_p, const m::vec3< T > &_min, const m::vec3< T > &_inv_diagonal )
+  KOKKOS_INLINE_FUNCTION m::vec3< std::uint64_t > quantize64( const m::vec3< T > &_p, const m::vec3< T > &_min,
+                                                              const m::vec3< T > &_inv_diagonal )
   {
     // Normalize
     auto norm = ( _p - _min ) * _inv_diagonal;
@@ -205,8 +198,7 @@ namespace bvh
     template<>
     struct quantize_impl< std::uint32_t >
     {
-      template< typename... Args >
-      static KOKKOS_INLINE_FUNCTION auto quantize( Args &&... _args )
+      template< typename... Args > static KOKKOS_INLINE_FUNCTION auto quantize( Args &&..._args )
       {
         return quantize32( std::forward< Args >( _args )... );
       }
@@ -215,8 +207,7 @@ namespace bvh
     template<>
     struct quantize_impl< std::uint64_t >
     {
-      template< typename... Args >
-      static KOKKOS_INLINE_FUNCTION auto quantize( Args &&... _args )
+      template< typename... Args > static KOKKOS_INLINE_FUNCTION auto quantize( Args &&..._args )
       {
         return quantize64( std::forward< Args >( _args )... );
       }
@@ -224,8 +215,8 @@ namespace bvh
   }
 
   template< typename B, typename T >
-  KOKKOS_INLINE_FUNCTION auto
-  quantize( const m::vec3< T > &_p, const m::vec3< T > &_min, const m::vec3< T > &_inv_diagonal )
+  KOKKOS_INLINE_FUNCTION auto quantize( const m::vec3< T > &_p, const m::vec3< T > &_min,
+                                        const m::vec3< T > &_inv_diagonal )
   {
     return detail::quantize_impl< B >::quantize( _p, _min, _inv_diagonal );
   }

--- a/src/bvh/kdop.hpp
+++ b/src/bvh/kdop.hpp
@@ -56,8 +56,8 @@ namespace bvh
   template< typename T >
   struct extent
   {
-    T min = std::numeric_limits< T >::max(); ///< The lower bound of an extent.
-    T max = std::numeric_limits< T >::lowest(); ///< The upper bound of an extent.
+    T min = m::max_double; ///< The lower bound of an extent.
+    T max = m::lowest_double; ///< The upper bound of an extent.
 
     /**
      *  The length of an extent.
@@ -236,7 +236,7 @@ namespace bvh
      *  \return                   the constructed k-DOP.
      */
     template< typename InputIterator >
-    static Derived from_vertices( InputIterator _begin, InputIterator _end, T _epsilon = T{ 0 } )
+    static KOKKOS_INLINE_FUNCTION Derived from_vertices( InputIterator _begin, InputIterator _end, T _epsilon = T{ 0 } )
     {
       Derived ret;
 
@@ -271,7 +271,7 @@ namespace bvh
      *  \return           the constructed k-DOP.
      */
     template< typename Vec >
-    static Derived from_sphere( const Vec &_center, T _radius )
+    static KOKKOS_INLINE_FUNCTION Derived from_sphere( const Vec &_center, T _radius )
     {
       Derived ret;
 
@@ -294,7 +294,7 @@ namespace bvh
      *  \param _radius    the radius of the sphere.
      *  \return           the constructed \f$k\f$-DOP.
      */
-    static Derived from_sphere( T _x, T _y, T _z, T _radius )
+    static KOKKOS_INLINE_FUNCTION Derived from_sphere( T _x, T _y, T _z, T _radius )
     {
       return from_sphere( m::vec3< T >( _x, _y, _z ), _radius );
     }
@@ -305,7 +305,7 @@ namespace bvh
      *
      * \param _amount The amount to grow.
      */
-    void inflate( arithmetic_type _amount )
+    KOKKOS_INLINE_FUNCTION void inflate( arithmetic_type _amount )
     {
       for ( int i = 0; i < K / 2; ++i )
       {
@@ -353,12 +353,12 @@ namespace bvh
      */
     int longest_axis() const
     {
-      auto iter = std::max_element( extents.begin(), extents.end(),
+      auto iter = std::max_element( extents.data(), extents.data() + K / 2,
                                 []( const extent< T > &_lhs, const extent< T > &_rhs ) {
                                   return _lhs.length() < _rhs.length();
                                 });
 
-      return static_cast< int >( std::distance( extents.begin(), iter ) );
+      return static_cast< int >( std::distance( extents.data(), iter ) );
     }
 
     /**
@@ -474,8 +474,8 @@ namespace bvh
     friend std::ostream &operator<<( std::ostream &os, const kdop_base &_kdop )
     {
       os << K << "-dop: ";
-      for ( auto &&e : _kdop.extents )
-        os << "[" << e.min << ", " << e.max << "] ";
+      for ( std::size_t i = 0; i < K / 2; ++i )
+        os << "[" << _kdop.extents[i].min << ", " << _kdop.extents[i].max << "] ";
 
       return os;
     }

--- a/src/bvh/kdop.hpp
+++ b/src/bvh/kdop.hpp
@@ -260,8 +260,7 @@ namespace bvh
     }
 
     template< size_t N >
-    static KOKKOS_INLINE_FUNCTION Derived from_vertices( const Kokkos::Array< m::vec3< T >, N > &_array,
-                                                         T _epsilon = T{ 0 } )
+    static KOKKOS_INLINE_FUNCTION Derived from_vertices( const Kokkos::Array< m::vec3< T >, N > &_array, T _epsilon = T{ 0 } )
     {
       Derived ret;
 

--- a/src/bvh/kdop.hpp
+++ b/src/bvh/kdop.hpp
@@ -38,11 +38,9 @@
 #include "math/common.hpp"
 #include <algorithm>
 #include <cmath>
-#include "range.hpp"
+#include <Kokkos_Macros.hpp>
 #include "util/array.hpp"
 #include "util/attributes.hpp"
-#include "util/kokkos.hpp"
-#include "iterators/transform_iterator.hpp"
 #include <fmt/format.h>
 
 namespace bvh
@@ -161,8 +159,8 @@ namespace bvh
     static constexpr int num_axis = k / 2;
     using arithmetic_type = T;
 
-    BVH_INLINE kdop_base() = default;
-    BVH_INLINE ~kdop_base() = default;
+    KOKKOS_DEFAULTED_FUNCTION kdop_base() = default;
+    KOKKOS_DEFAULTED_FUNCTION ~kdop_base() = default;
 
     /**
      *  Create a k-DOP by merging a range of k-DOPs.

--- a/src/bvh/kdop.hpp
+++ b/src/bvh/kdop.hpp
@@ -54,8 +54,8 @@ namespace bvh
   template< typename T >
   struct extent
   {
-    T min = m::max_double; ///< The lower bound of an extent.
-    T max = m::lowest_double; ///< The upper bound of an extent.
+    T min = m::max_double;     ///< The lower bound of an extent.
+    T max = m::lowest_double;  ///< The upper bound of an extent.
 
     /**
      *  The length of an extent.
@@ -266,8 +266,7 @@ namespace bvh
      *  \param _radius    the radius of the sphere.
      *  \return           the constructed k-DOP.
      */
-    template< typename Vec >
-    static KOKKOS_INLINE_FUNCTION Derived from_sphere( const Vec &_center, T _radius )
+    template< typename Vec > static KOKKOS_INLINE_FUNCTION Derived from_sphere( const Vec &_center, T _radius )
     {
       Derived ret;
 
@@ -349,10 +348,9 @@ namespace bvh
      */
     int longest_axis() const
     {
-      auto iter = std::max_element( extents.data(), extents.data() + K / 2,
-                                []( const extent< T > &_lhs, const extent< T > &_rhs ) {
-                                  return _lhs.length() < _rhs.length();
-                                });
+      auto iter = std::max_element(
+        extents.data(), extents.data() + K / 2,
+        []( const extent< T > &_lhs, const extent< T > &_rhs ) { return _lhs.length() < _rhs.length(); } );
 
       return static_cast< int >( std::distance( extents.data(), iter ) );
     }

--- a/src/bvh/kdop.hpp
+++ b/src/bvh/kdop.hpp
@@ -169,8 +169,7 @@ namespace bvh
      *  \param _begin             the beginning k-DOP range
      *  \param _end               the end of the k-DOP range
      */
-    template< typename InputIterator >
-    kdop_base( InputIterator _begin, InputIterator _end )
+    template< typename InputIterator > kdop_base( InputIterator _begin, InputIterator _end )
     {
       if ( std::distance( _begin, _end ) == 0 )
         return;
@@ -205,8 +204,7 @@ namespace bvh
      *  \param _end               the end of the k-DOP range
      *  \return                   the constructed k-DOP.
      */
-    template< typename InputIterator >
-    static BVH_INLINE Derived from_kdops( InputIterator _begin, InputIterator _end )
+    template< typename InputIterator > static Derived from_kdops( InputIterator _begin, InputIterator _end )
     {
       return Derived( _begin, _end );
     }

--- a/src/bvh/kdop.hpp
+++ b/src/bvh/kdop.hpp
@@ -260,7 +260,8 @@ namespace bvh
     }
 
     template< size_t N >
-    static KOKKOS_INLINE_FUNCTION Derived from_vertices( const Kokkos::Array< m::vec3< T >, N > &_array, T _epsilon = T{ 0 } )
+    static KOKKOS_INLINE_FUNCTION Derived from_vertices( const Kokkos::Array< m::vec3< T >, N > &_array,
+                                                         T _epsilon = T{ 0 } )
     {
       Derived ret;
 

--- a/src/bvh/kdop.hpp
+++ b/src/bvh/kdop.hpp
@@ -136,8 +136,8 @@ namespace bvh
     const extent< T > &_rhs ) noexcept
   {
     extent< T > ret;
-    ret.min = std::min( _lhs.min, _rhs.min );
-    ret.max = std::max( _lhs.max, _rhs.max );
+    ret.min = Kokkos::min( _lhs.min, _rhs.min );
+    ret.max = Kokkos::max( _lhs.max, _rhs.max );
 
     return ret;
   }
@@ -251,8 +251,8 @@ namespace bvh
         for ( auto iter = beg; iter != _end; ++iter )
         {
           proj = Derived::project( *iter, normal_list[i] );
-          ret.extents[i].min = std::min( ret.extents[i].min, proj - _epsilon );
-          ret.extents[i].max = std::max( ret.extents[i].max, proj + _epsilon );
+          ret.extents[i].min = Kokkos::min( ret.extents[i].min, proj - _epsilon );
+          ret.extents[i].max = Kokkos::max( ret.extents[i].max, proj + _epsilon );
         }
       }
 
@@ -441,8 +441,8 @@ namespace bvh
       for ( int i = 0; i < K / 2; ++i )
       {
         auto projected = Derived::project( _point, normal_list[i] );
-        extents[i].min = std::min( extents[i].min, projected - _epsilon );
-        extents[i].max = std::max( extents[i].max, projected + _epsilon );
+        extents[i].min = Kokkos::min( extents[i].min, projected - _epsilon );
+        extents[i].max = Kokkos::max( extents[i].max, projected + _epsilon );
       }
     }
 

--- a/src/bvh/kdop.hpp
+++ b/src/bvh/kdop.hpp
@@ -169,7 +169,8 @@ namespace bvh
      *  \param _begin             the beginning k-DOP range
      *  \param _end               the end of the k-DOP range
      */
-    template< typename InputIterator > kdop_base( InputIterator _begin, InputIterator _end )
+    template< typename InputIterator >
+    kdop_base( InputIterator _begin, InputIterator _end )
     {
       if ( std::distance( _begin, _end ) == 0 )
         return;
@@ -204,7 +205,8 @@ namespace bvh
      *  \param _end               the end of the k-DOP range
      *  \return                   the constructed k-DOP.
      */
-    template< typename InputIterator > static Derived from_kdops( InputIterator _begin, InputIterator _end )
+    template< typename InputIterator >
+    static Derived from_kdops( InputIterator _begin, InputIterator _end )
     {
       return Derived( _begin, _end );
     }
@@ -260,7 +262,8 @@ namespace bvh
     }
 
     template< size_t N >
-    static KOKKOS_INLINE_FUNCTION Derived from_vertices( const Kokkos::Array< m::vec3< T >, N > &_array, T _epsilon = T{ 0 } )
+    static KOKKOS_INLINE_FUNCTION Derived
+    from_vertices( const Kokkos::Array< m::vec3< T >, N > &_array, T _epsilon = T{ 0 } )
     {
       Derived ret;
 
@@ -292,7 +295,8 @@ namespace bvh
      *  \param _radius    the radius of the sphere.
      *  \return           the constructed k-DOP.
      */
-    template< typename Vec > static KOKKOS_INLINE_FUNCTION Derived from_sphere( const Vec &_center, T _radius )
+    template< typename Vec >
+    static KOKKOS_INLINE_FUNCTION Derived from_sphere( const Vec &_center, T _radius )
     {
       Derived ret;
 
@@ -315,7 +319,8 @@ namespace bvh
      *  \param _radius    the radius of the sphere.
      *  \return           the constructed \f$k\f$-DOP.
      */
-    static KOKKOS_INLINE_FUNCTION Derived from_sphere( T _x, T _y, T _z, T _radius )
+    static KOKKOS_INLINE_FUNCTION
+    Derived from_sphere( T _x, T _y, T _z, T _radius )
     {
       return from_sphere( m::vec3< T >( _x, _y, _z ), _radius );
     }
@@ -326,7 +331,8 @@ namespace bvh
      *
      * \param _amount The amount to grow.
      */
-    KOKKOS_INLINE_FUNCTION void inflate( arithmetic_type _amount )
+    KOKKOS_INLINE_FUNCTION
+    void inflate( arithmetic_type _amount )
     {
       for ( int i = 0; i < K / 2; ++i )
       {

--- a/src/bvh/math/common.hpp
+++ b/src/bvh/math/common.hpp
@@ -56,13 +56,21 @@ namespace bvh
     constexpr double epsilon = DBL_EPSILON;
     constexpr double epsilonf = FLT_EPSILON;
 
+    constexpr double lowest_double = -DBL_MAX;
+    constexpr double max_double = DBL_MAX;
+
     template< typename T >
     constexpr T epsilon_value = T{};
+    template<>
+    constexpr double epsilon_value<float> = FLT_EPSILON;
     template<>
     constexpr double epsilon_value<double> = DBL_EPSILON;
 #else
     constexpr double epsilon = std::numeric_limits< double >::epsilon();
     constexpr double epsilonf = std::numeric_limits< float >::epsilon();
+
+    constexpr double lowest_double = std::numeric_limits< double >::lowest();
+    constexpr double max_double = std::numeric_limits< double >::max();
 
     template< typename T >
     constexpr T epsilon_value = std::numeric_limits< T >::epsilon();

--- a/src/bvh/math/common.hpp
+++ b/src/bvh/math/common.hpp
@@ -61,10 +61,8 @@ namespace bvh
 
     template< typename T >
     constexpr T epsilon_value = T{};
-    template<>
-    constexpr double epsilon_value<float> = FLT_EPSILON;
-    template<>
-    constexpr double epsilon_value<double> = DBL_EPSILON;
+    template<> constexpr double epsilon_value< float > = FLT_EPSILON;
+    template<> constexpr double epsilon_value< double > = DBL_EPSILON;
 #else
     constexpr double epsilon = std::numeric_limits< double >::epsilon();
     constexpr double epsilonf = std::numeric_limits< float >::epsilon();

--- a/src/bvh/math/ops/vec_bool_ops.hpp
+++ b/src/bvh/math/ops/vec_bool_ops.hpp
@@ -35,7 +35,6 @@
 
 #include "../vector_traits.hpp"
 #include "vec_base_ops.hpp"
-#include "../promotion.hpp"
 #include "../../util/bits.hpp"
 
 namespace bvh

--- a/src/bvh/math/storage/constexpr_vec_storage.hpp
+++ b/src/bvh/math/storage/constexpr_vec_storage.hpp
@@ -33,10 +33,9 @@
 #ifndef INC_BVH_MATH_STORAGE_CONSTEXPR_VEC_STORAGE_HPP
 #define INC_BVH_MATH_STORAGE_CONSTEXPR_VEC_STORAGE_HPP
 
-#include <type_traits>
-#include <utility>
+#include <Kokkos_Macros.hpp>
 
-#include "../compiler.hpp"
+#include "../../util/attributes.hpp"
 
 namespace bvh
 {
@@ -60,15 +59,15 @@ namespace bvh
             d[i] = _s;
         }
 
-        BVH_INLINE ~constexpr_vec_storage() = default;
+        KOKKOS_DEFAULTED_FUNCTION ~constexpr_vec_storage() = default;
 
-        constexpr BVH_INLINE constexpr_vec_storage( const constexpr_vec_storage & ) = default;
+        constexpr KOKKOS_DEFAULTED_FUNCTION constexpr_vec_storage( const constexpr_vec_storage & ) = default;
 
-        constexpr BVH_INLINE constexpr_vec_storage( constexpr_vec_storage && ) = default;
+        constexpr KOKKOS_DEFAULTED_FUNCTION constexpr_vec_storage( constexpr_vec_storage && ) = default;
 
-        constexpr BVH_INLINE constexpr_vec_storage &operator=( const constexpr_vec_storage & ) = default;
+        constexpr KOKKOS_DEFAULTED_FUNCTION constexpr_vec_storage &operator=( const constexpr_vec_storage & ) = default;
 
-        constexpr BVH_INLINE constexpr_vec_storage &operator=( constexpr_vec_storage && ) = default;
+        constexpr KOKKOS_DEFAULTED_FUNCTION constexpr_vec_storage &operator=( constexpr_vec_storage && ) = default;
 
         constexpr BVH_INLINE T &operator[]( int i )
         { return d[i]; }

--- a/src/bvh/math/storage/vec_storage.hpp
+++ b/src/bvh/math/storage/vec_storage.hpp
@@ -78,15 +78,15 @@ namespace bvh
             : chunks{}
         {}
 
-        KOKKOS_INLINE_FUNCTION ~vec_storage() noexcept = default;
+        KOKKOS_DEFAULTED_FUNCTION ~vec_storage() noexcept = default;
 
-        constexpr KOKKOS_INLINE_FUNCTION vec_storage( const vec_storage & ) noexcept = default;
+        constexpr KOKKOS_DEFAULTED_FUNCTION vec_storage( const vec_storage & ) noexcept = default;
 
-        constexpr KOKKOS_INLINE_FUNCTION vec_storage( vec_storage && ) noexcept = default;
+        constexpr KOKKOS_DEFAULTED_FUNCTION vec_storage( vec_storage && ) noexcept = default;
 
-        constexpr KOKKOS_INLINE_FUNCTION vec_storage &operator=( const vec_storage & ) noexcept = default;
+        constexpr KOKKOS_DEFAULTED_FUNCTION vec_storage &operator=( const vec_storage & ) noexcept = default;
 
-        constexpr KOKKOS_INLINE_FUNCTION vec_storage &operator=( vec_storage && ) noexcept = default;
+        constexpr KOKKOS_DEFAULTED_FUNCTION vec_storage &operator=( vec_storage && ) noexcept = default;
 
         constexpr KOKKOS_INLINE_FUNCTION T &operator[]( int i ) noexcept
         { return reinterpret_cast< T * >( chunks )[i]; }

--- a/src/bvh/node.hpp
+++ b/src/bvh/node.hpp
@@ -68,47 +68,47 @@ namespace bvh
     using value_type = T;       ///< The `ContactEntity`-conforming type stored in the node
     using kdop_type = KDop;     ///< The type of \f$k\f$-DOP used as bounding volumes.
     using data_type = NodeData; ///< The type of additional user data, `void` if no data specified
-  
+
     using size_type = std::size_t;  ///< The size used for representing distances and depths in the node
-    
+
     // TODO: remove default constructor
     bvh_node() : m_parent_offset( 0 ), m_child_offsets{}, m_entity_offsets{} {}
-  
+
     /**
      *  Get the parent of the node.
      *
      *  \return the parent of the node or `this` if this is the root node
      */
     bvh_node *parent() noexcept { return this + m_parent_offset; }
-  
+
     /**
      *  Get the parent of the node.
      *
      *  \return the parent of the node or `this` if this is the root node
      */
     const bvh_node *parent() const noexcept { return this + m_parent_offset; }
-  
+
     /**
      *  Get the left child of the node.
      *
      *  \return the left child of the node or `this` if there is no left child
      */
     bvh_node *left() noexcept { return this + m_child_offsets[0]; }
-  
+
     /**
      *  Get the left child of the node.
      *
      *  \return the left child of the node or `this` if there is no left child
      */
     const bvh_node *left() const noexcept { return this + m_child_offsets[0]; }
-  
+
     /**
      *  Get the right child of the node.
      *
      *  \return the right child of the node or `this` if there is no right child
      */
     bvh_node *right() noexcept { return this + m_child_offsets[1]; }
-  
+
     /**
      *  Get the right child of the node.
      *
@@ -141,7 +141,7 @@ namespace bvh
      * \return          the offset of the child or 0 if there is no child at that index
      */
     std::ptrdiff_t get_child_offset( int _child ) const noexcept { return m_child_offsets[_child]; }
-    
+
     /**
      *  Get whether or not the node is a leaf node.
      *
@@ -151,7 +151,7 @@ namespace bvh
     {
       return !has_left() && !has_right();
     }
-  
+
     /**
      *  Get the depth of the tree at the node.
      *
@@ -192,7 +192,7 @@ namespace bvh
     {
       return is_leaf() ? 1 : std::max( left()->depth(), right()->depth() ) + 1;
     }
-  
+
     /**
      *  Get the level of the tree at the node.
      *
@@ -207,7 +207,7 @@ namespace bvh
         ++level;
         p = p->parent();
       }
-    
+
       return level;
     }
 
@@ -220,7 +220,7 @@ namespace bvh
     {
       m_parent_offset = _offset;
     }
-    
+
     /**
      *  Construct a node by moving in a k_DOP and giving a parent node.
      *
@@ -234,7 +234,7 @@ namespace bvh
         m_entity_offsets{}
     {
     }
-    
+
     /**
      *  Get the number of elements in this node.
      *
@@ -244,16 +244,16 @@ namespace bvh
     {
       if ( this->is_leaf() )
         return m_entity_offsets[1] - m_entity_offsets[0];
-  
+
       return this->left()->count() + this->right()->count();
     }
-    
+
     /**
      *  Get the bounding volume of the node
      *
      *  \return the k-DOP bounding the node
      */
-    const kdop_type &kdop() const noexcept { return m_kdop; }
+    const KOKKOS_INLINE_FUNCTION kdop_type &kdop() const noexcept { return m_kdop; }
 
     /**
      * Get the offsets of the entities into the entity array that this node represents. These offsets are returned
@@ -307,7 +307,7 @@ namespace bvh
         && ( _lhs.m_child_offsets == _rhs.m_child_offsets )
         && ( _lhs.m_entity_offsets == _rhs.m_entity_offsets );
     }
-    
+
   private:
 
     template< typename S,
@@ -315,14 +315,14 @@ namespace bvh
               typename K,
               typename N >
     friend void serialize( S &_s, const bvh_node< U, K, N > &_node );
-  
+
     std::ptrdiff_t m_parent_offset;
     array< std::ptrdiff_t, 2 > m_child_offsets;
 
     KDop m_kdop;
     array< std::size_t, 2 > m_entity_offsets;
   };
-  
+
   namespace detail
   {
     template< typename T, typename KDop, typename NodeData >
@@ -331,14 +331,14 @@ namespace bvh
                     const dynarray< T > &_leafs)
     {
       bool last = _last_stack.back();
-      
+
       for ( std::size_t i = 0; i < _last_stack.size() - 1; ++i )
       {
         _strm << ( ( !_last_stack[i] ) ? "\u2502" : " " ) << ' ';
       }
-  
+
       _strm << ( last ? "\u2514 " : "\u251c " );
-      
+
       auto level = _node.level();
       if ( _node.is_leaf() )
       {
@@ -355,15 +355,15 @@ namespace bvh
         _last_stack.push_back( !_node.right() );
         dump_node_impl( _strm, *_node.left(), _last_stack, _leafs );
       }
-    
+
       if ( _node.has_right() )
       {
         _last_stack.push_back( true );
         dump_node_impl( _strm, *_node.right(), _last_stack, _leafs );
       }
-      
+
       _last_stack.pop_back();
-    
+
       return _strm;
     }
   }
@@ -384,7 +384,7 @@ namespace bvh
   {
     std::vector< bool > last_stack;
     last_stack.push_back( true );
-    
+
     return detail::dump_node_impl( _strm, _node, last_stack, _leafs );
   }
 }

--- a/src/bvh/node.hpp
+++ b/src/bvh/node.hpp
@@ -261,8 +261,8 @@ namespace bvh
      *
      * \return  the offsets
      */
-    std::array< std::size_t, 2 > &get_patch() noexcept { return m_entity_offsets; }
-    const std::array< std::size_t, 2 > &get_patch() const noexcept { return m_entity_offsets; }
+    array< std::size_t, 2 > &get_patch() noexcept { return m_entity_offsets; }
+    const array< std::size_t, 2 > &get_patch() const noexcept { return m_entity_offsets; }
 
     /**
      * Set the offsets into the entity array that this node represents. The first offset is treated as a beginning
@@ -316,10 +316,10 @@ namespace bvh
     friend void serialize( S &_s, const bvh_node< U, K, N > &_node );
   
     std::ptrdiff_t m_parent_offset;
-    std::array< std::ptrdiff_t, 2 > m_child_offsets;
+    array< std::ptrdiff_t, 2 > m_child_offsets;
     
     KDop m_kdop;
-    std::array< std::size_t, 2 > m_entity_offsets;
+    array< std::size_t, 2 > m_entity_offsets;
   };
   
   namespace detail

--- a/src/bvh/node.hpp
+++ b/src/bvh/node.hpp
@@ -262,7 +262,6 @@ namespace bvh
      * \return  the offsets
      */
     array< std::size_t, 2 > &get_patch() noexcept { return m_entity_offsets; }
-
     const array< std::size_t, 2 > &get_patch() const noexcept { return m_entity_offsets; }
 
     /**

--- a/src/bvh/node.hpp
+++ b/src/bvh/node.hpp
@@ -262,6 +262,7 @@ namespace bvh
      * \return  the offsets
      */
     array< std::size_t, 2 > &get_patch() noexcept { return m_entity_offsets; }
+
     const array< std::size_t, 2 > &get_patch() const noexcept { return m_entity_offsets; }
 
     /**
@@ -317,7 +318,7 @@ namespace bvh
   
     std::ptrdiff_t m_parent_offset;
     array< std::ptrdiff_t, 2 > m_child_offsets;
-    
+
     KDop m_kdop;
     array< std::size_t, 2 > m_entity_offsets;
   };

--- a/src/bvh/patch.hpp
+++ b/src/bvh/patch.hpp
@@ -84,9 +84,11 @@ namespace bvh
       m_size = _span.size();
     }
 
-    index_type global_id() const noexcept { return m_global_id; }
-    kdop_type kdop() const noexcept { return m_kdop; }
-    m::vec3< float_type > centroid() const noexcept { return m_centroid; }
+    KOKKOS_INLINE_FUNCTION index_type global_id() const noexcept { return m_global_id; }
+
+    KOKKOS_INLINE_FUNCTION kdop_type kdop() const noexcept { return m_kdop; }
+
+    KOKKOS_INLINE_FUNCTION m::vec3< float_type > centroid() const noexcept { return m_centroid; }
 
     bool empty() const noexcept { return m_size == 0; }
     size_type size() const noexcept { return m_size; }
@@ -122,23 +124,17 @@ namespace bvh
     m::vec3< float_type > m_centroid = m::vec3< float_type >::zeros();
   };
 
-  template< typename KDop >
-  decltype(auto)
-  get_entity_kdop( const patch< KDop > &_patch )
+  template< typename KDop > KOKKOS_INLINE_FUNCTION decltype( auto ) get_entity_kdop( const patch< KDop > &_patch )
   {
     return _patch.kdop();
   }
 
-  template< typename KDop >
-  decltype(auto)
-  get_entity_global_id( const patch< KDop > &_patch )
+  template< typename KDop > KOKKOS_INLINE_FUNCTION decltype( auto ) get_entity_global_id( const patch< KDop > &_patch )
   {
     return _patch.global_id();
   }
 
-  template< typename KDop >
-  decltype(auto)
-  get_entity_centroid( const patch< KDop > &_patch )
+  template< typename KDop > KOKKOS_INLINE_FUNCTION decltype( auto ) get_entity_centroid( const patch< KDop > &_patch )
   {
     return _patch.centroid();
   }

--- a/src/bvh/snapshot.hpp
+++ b/src/bvh/snapshot.hpp
@@ -78,18 +78,18 @@ namespace bvh
         : m_global_id( _gid ), m_kdop( _bounds ), m_centroid( _centroid ), m_local_index( _local_index )
     {}
 
-    KOKKOS_INLINE_FUNCTION entity_snapshot() = default;
-    KOKKOS_INLINE_FUNCTION ~entity_snapshot() = default;
+    KOKKOS_DEFAULTED_FUNCTION entity_snapshot() = default;
+    KOKKOS_DEFAULTED_FUNCTION ~entity_snapshot() = default;
 
-    KOKKOS_INLINE_FUNCTION
+    KOKKOS_DEFAULTED_FUNCTION
     entity_snapshot( const entity_snapshot & ) = default;
 
-    KOKKOS_INLINE_FUNCTION
+    KOKKOS_DEFAULTED_FUNCTION
     entity_snapshot( entity_snapshot && ) = default;
 
-    KOKKOS_INLINE_FUNCTION
+    KOKKOS_DEFAULTED_FUNCTION
     entity_snapshot &operator=( const entity_snapshot & ) = default;
-    KOKKOS_INLINE_FUNCTION
+    KOKKOS_DEFAULTED_FUNCTION
     entity_snapshot &operator=( entity_snapshot && ) = default;
 
     KOKKOS_INLINE_FUNCTION index_type global_id() const noexcept { return m_global_id; }

--- a/src/bvh/snapshot.hpp
+++ b/src/bvh/snapshot.hpp
@@ -45,8 +45,7 @@ namespace bvh
 {
   namespace detail
   {
-    template< typename Entity >
-    KOKKOS_INLINE_FUNCTION auto convert_centroid( const Entity &_ent )
+    template< typename Entity > KOKKOS_INLINE_FUNCTION auto convert_centroid( const Entity &_ent )
     {
       using kdop_type = typename element_traits< Entity >::kdop_type;
       using arithmetic_type = typename kdop_type::arithmetic_type;

--- a/src/bvh/snapshot.hpp
+++ b/src/bvh/snapshot.hpp
@@ -46,7 +46,7 @@ namespace bvh
   namespace detail
   {
     template< typename Entity >
-    auto convert_centroid( const Entity &_ent )
+    KOKKOS_INLINE_FUNCTION auto convert_centroid( const Entity &_ent )
     {
       using kdop_type = typename element_traits< Entity >::kdop_type;
       using arithmetic_type = typename kdop_type::arithmetic_type;

--- a/src/bvh/snapshot.hpp
+++ b/src/bvh/snapshot.hpp
@@ -45,7 +45,8 @@ namespace bvh
 {
   namespace detail
   {
-    template< typename Entity > KOKKOS_INLINE_FUNCTION auto convert_centroid( const Entity &_ent )
+    template< typename Entity >
+    KOKKOS_INLINE_FUNCTION auto convert_centroid( const Entity &_ent )
     {
       using kdop_type = typename element_traits< Entity >::kdop_type;
       using arithmetic_type = typename kdop_type::arithmetic_type;

--- a/src/bvh/split/cluster.hpp
+++ b/src/bvh/split/cluster.hpp
@@ -96,7 +96,6 @@ namespace bvh
     assert( m_hashes.extent( 0 ) == _elements.extent( 0 ) );
     assert( m_hashes.extent( 0 ) == _indices.extent( 0 ) );
 
-    // REMOVE_ME: debug here?
     const auto cluster_count = _splits.extent( 0 );
     const auto n = m_hashes.extent( 0 );
 

--- a/src/bvh/split/cluster.hpp
+++ b/src/bvh/split/cluster.hpp
@@ -140,7 +140,7 @@ namespace bvh
 
     // Exclude the last index from the range since there is not going
     // to be a split in the tree after it...
-    Kokkos::parallel_for( n - 1, [this] KOKKOS_FUNCTION( int _i ) {
+    Kokkos::parallel_for( n - 1, KOKKOS_CLASS_LAMBDA( int _i ) {
       auto mask = m_hashes( _i ) ^ m_hashes( _i + 1 );
       m_depths_indices( _i ) = _i;
 
@@ -154,12 +154,12 @@ namespace bvh
 
     // We want the first cluster_count indices -- but they have to be in sorted index order
     // Mark these with 1, then we can execute an exclusive scan to re-index
-    Kokkos::parallel_for( n - 1, [this, cluster_count] KOKKOS_FUNCTION( std::size_t _i ) {
+    Kokkos::parallel_for( n - 1, KOKKOS_CLASS_LAMBDA( std::size_t _i ) {
       m_reindex( m_depths_indices( _i ) ) = ( _i < cluster_count ) ? 1 : 0;
     } );
 
     prefix_sum( m_reindex );
-    Kokkos::parallel_for( n - 1, [this, _splits, cluster_count] KOKKOS_FUNCTION( std::size_t _i ) {
+    Kokkos::parallel_for( n - 1, KOKKOS_CLASS_LAMBDA( std::size_t _i ) {
       if ( _i < cluster_count )
       {
         auto new_idx = m_reindex( m_depths_indices( _i ) );

--- a/src/bvh/split/cluster.hpp
+++ b/src/bvh/split/cluster.hpp
@@ -144,9 +144,7 @@ namespace bvh
       auto mask = m_hashes( _i ) ^ m_hashes( _i + 1 );
       m_depths_indices( _i ) = _i;
 
-      // Kokkos doesn't currently offer clz but they do offer int_log2 but in the Impl namespace ;_;
-      constexpr int shift = sizeof(unsigned) * CHAR_BIT - 1;
-      m_depths( _i ) = ( mask != 0 ) ? shift - Kokkos::Impl::int_log2( mask ) : static_cast< unsigned >( -1 );  // this could break at any version of Kokkos...
+      m_depths( _i ) = ( mask != 0 ) ? clz( mask ) : static_cast< unsigned >( -1 );  // this could break at any version of Kokkos...
     } );
 
     // Sort in order of increasing depth

--- a/src/bvh/split/cluster.hpp
+++ b/src/bvh/split/cluster.hpp
@@ -157,6 +157,9 @@ namespace bvh
     // Mark these with 1, then we can execute an exclusive scan to re-index
     Kokkos::parallel_for( n - 1, KOKKOS_CLASS_LAMBDA( std::size_t _i ) {
       m_reindex( m_depths_indices( _i ) ) = ( _i < cluster_count ) ? 1 : 0;
+      printf( "cluster_count: %d\t_i: %d\t m_depths_indices(_i): %d\tm_reindex(...): %d\n",
+              static_cast< int >( cluster_count ), static_cast< int >( _i ),
+              static_cast< int >( m_depths_indices( _i ) ), static_cast< int >( m_reindex( m_depths_indices( _i ) ) ) );
     } );
 
     prefix_sum( m_reindex );

--- a/src/bvh/split/cluster.hpp
+++ b/src/bvh/split/cluster.hpp
@@ -157,9 +157,6 @@ namespace bvh
     // Mark these with 1, then we can execute an exclusive scan to re-index
     Kokkos::parallel_for( n - 1, KOKKOS_CLASS_LAMBDA( std::size_t _i ) {
       m_reindex( m_depths_indices( _i ) ) = ( _i < cluster_count ) ? 1 : 0;
-      printf( "cluster_count: %d\t_i: %d\t m_depths_indices(_i): %d\tm_reindex(...): %d\n",
-              static_cast< int >( cluster_count ), static_cast< int >( _i ),
-              static_cast< int >( m_depths_indices( _i ) ), static_cast< int >( m_reindex( m_depths_indices( _i ) ) ) );
     } );
 
     prefix_sum( m_reindex );

--- a/src/bvh/split/cluster.hpp
+++ b/src/bvh/split/cluster.hpp
@@ -96,6 +96,7 @@ namespace bvh
     assert( m_hashes.extent( 0 ) == _elements.extent( 0 ) );
     assert( m_hashes.extent( 0 ) == _indices.extent( 0 ) );
 
+    // REMOVE_ME: debug here?
     const auto cluster_count = _splits.extent( 0 );
     const auto n = m_hashes.extent( 0 );
 

--- a/src/bvh/split/split.hpp
+++ b/src/bvh/split/split.hpp
@@ -141,11 +141,12 @@ namespace bvh
 
       Kokkos::View< size_t*, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> > h_perm(_perm.data(), _perm.size());
       Kokkos::View< bvh::entity_snapshot*, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> > h_elements(_elements.data(), _elements.size());
-      Kokkos::parallel_for("CopyLoop", Kokkos::RangePolicy< Kokkos::DefaultHostExecutionSpace >( 0, _elements.size() ), [=](const int& i) {
-                       auto tmp_pair = combi[i];
-                       h_elements[i] = std::get<0>( tmp_pair );
-                       h_perm(i) = std::get<1>( tmp_pair );
-                     } );
+      Kokkos::parallel_for( "CopyLoop", Kokkos::RangePolicy< Kokkos::DefaultHostExecutionSpace >( 0, _elements.size() ),
+                            [=]( const int &i ) {
+        auto tmp_pair = combi[i];
+        h_elements[i] = std::get< 0 >( tmp_pair );
+        h_perm( i ) = std::get< 1 >( tmp_pair );
+      } );
 
       auto delta = std::distance( combi.begin(), split_combi );
       if ( ( combi.begin() == split_combi ) || ( combi.end() == split_combi ) ) {

--- a/src/bvh/split/split.hpp
+++ b/src/bvh/split/split.hpp
@@ -141,12 +141,11 @@ namespace bvh
 
       Kokkos::View< size_t*, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> > h_perm(_perm.data(), _perm.size());
       Kokkos::View< bvh::entity_snapshot*, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> > h_elements(_elements.data(), _elements.size());
-      Kokkos::parallel_for( "CopyLoop", Kokkos::RangePolicy< Kokkos::DefaultHostExecutionSpace >( 0, _elements.size() ),
-                            [=]( const int &i ) {
-        auto tmp_pair = combi[i];
-        h_elements[i] = std::get< 0 >( tmp_pair );
-        h_perm( i ) = std::get< 1 >( tmp_pair );
-      } );
+      Kokkos::parallel_for("CopyLoop", Kokkos::RangePolicy< Kokkos::DefaultHostExecutionSpace >( 0, _elements.size() ), [=](const int& i) {
+                       auto tmp_pair = combi[i];
+                       h_elements[i] = std::get<0>( tmp_pair );
+                       h_perm(i) = std::get<1>( tmp_pair );
+                     } );
 
       auto delta = std::distance( combi.begin(), split_combi );
       if ( ( combi.begin() == split_combi ) || ( combi.end() == split_combi ) ) {

--- a/src/bvh/split/split.hpp
+++ b/src/bvh/split/split.hpp
@@ -43,6 +43,8 @@
 
 #include "element_permutations.hpp"
 
+#include <Kokkos_Core_fwd.hpp>
+#include <impl/Kokkos_HostThreadTeam.hpp>
 #include <iterator>
 #include <numeric>
 #include <algorithm>
@@ -296,7 +298,7 @@ namespace bvh
     if ( _depth > 0 ) {
       std::vector< std::pair< Element, size_t > > combi( _elements.size() );
       Kokkos::View< std::pair< Element, size_t >*, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> > h_combi(combi.data(), _elements.size());
-      Kokkos::parallel_for("CopyInit", _elements.size(), KOKKOS_LAMBDA (const int& i) {
+      Kokkos::parallel_for("CopyInit", Kokkos::RangePolicy< Kokkos::DefaultHostExecutionSpace >( 0, static_cast< int >( _elements.size() ) ), KOKKOS_LAMBDA (int i) {
                      h_combi[i] = std::make_pair( _elements[i], i );
                      } );
       detail::split_permutations_recursive_impl_ml< SplittingMethod, AxisSelector >( _elements, _depth - 1,

--- a/src/bvh/split/split.hpp
+++ b/src/bvh/split/split.hpp
@@ -141,7 +141,7 @@ namespace bvh
 
       Kokkos::View< size_t*, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> > h_perm(_perm.data(), _perm.size());
       Kokkos::View< bvh::entity_snapshot*, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> > h_elements(_elements.data(), _elements.size());
-      Kokkos::parallel_for("CopyLoop", _elements.size(), KOKKOS_LAMBDA (const int& i) {
+      Kokkos::parallel_for("CopyLoop", Kokkos::RangePolicy< Kokkos::DefaultHostExecutionSpace >( 0, _elements.size() ), [=](const int& i) {
                        auto tmp_pair = combi[i];
                        h_elements[i] = std::get<0>( tmp_pair );
                        h_perm(i) = std::get<1>( tmp_pair );
@@ -301,7 +301,7 @@ namespace bvh
       Kokkos::parallel_for(
         "CopyInit",
         Kokkos::RangePolicy< Kokkos::DefaultHostExecutionSpace >( 0, static_cast< int >( _elements.size() ) ),
-        KOKKOS_LAMBDA( int i ) { h_combi[i] = std::make_pair( _elements[i], i ); } );
+        [=]( int i ) { h_combi[i] = std::make_pair( _elements[i], i ); } );
       detail::split_permutations_recursive_impl_ml< SplittingMethod, AxisSelector >( _elements, _depth - 1,
                         _permutations->indices.begin(),
                         _permutations->indices, _permutations->splits,

--- a/src/bvh/split/split.hpp
+++ b/src/bvh/split/split.hpp
@@ -298,9 +298,10 @@ namespace bvh
     if ( _depth > 0 ) {
       std::vector< std::pair< Element, size_t > > combi( _elements.size() );
       Kokkos::View< std::pair< Element, size_t >*, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> > h_combi(combi.data(), _elements.size());
-      Kokkos::parallel_for("CopyInit", Kokkos::RangePolicy< Kokkos::DefaultHostExecutionSpace >( 0, static_cast< int >( _elements.size() ) ), KOKKOS_LAMBDA (int i) {
-                     h_combi[i] = std::make_pair( _elements[i], i );
-                     } );
+      Kokkos::parallel_for(
+        "CopyInit",
+        Kokkos::RangePolicy< Kokkos::DefaultHostExecutionSpace >( 0, static_cast< int >( _elements.size() ) ),
+        KOKKOS_LAMBDA( int i ) { h_combi[i] = std::make_pair( _elements[i], i ); } );
       detail::split_permutations_recursive_impl_ml< SplittingMethod, AxisSelector >( _elements, _depth - 1,
                         _permutations->indices.begin(),
                         _permutations->indices, _permutations->splits,

--- a/src/bvh/traits.hpp
+++ b/src/bvh/traits.hpp
@@ -55,61 +55,58 @@ namespace bvh
   namespace detail
   {
     template< typename Element >
-    constexpr auto get_kdop_impl( const Element &_element, overload_priority< 1 > )
-      -> decltype( get_entity_kdop( _element ) )
+    constexpr KOKKOS_INLINE_FUNCTION auto
+      get_kdop_impl( const Element &_element, overload_priority< 1 > ) -> decltype( get_entity_kdop( _element ) )
     {
       return get_entity_kdop( _element );
     }
 
     template< typename Element >
-    constexpr auto get_kdop_impl( const Element &_element, overload_priority< 0 > )
-      -> decltype( _element.kdop() )
+    constexpr KOKKOS_INLINE_FUNCTION auto get_kdop_impl( const Element &_element,
+                                                         overload_priority< 0 > ) -> decltype( _element.kdop() )
     {
       return _element.kdop();
     }
 
-    template< typename Element >
-    constexpr auto get_kdop( const Element &_element )
+    template< typename Element > constexpr KOKKOS_INLINE_FUNCTION auto get_kdop( const Element &_element )
     {
       return get_kdop_impl( _element, overload_priority< 1 >{} );
     }
 
     template< typename Element >
-    constexpr auto get_centroid_impl( const Element &_element, overload_priority< 1 > )
+    constexpr KOKKOS_INLINE_FUNCTION auto get_centroid_impl( const Element &_element, overload_priority< 1 > )
       -> decltype( get_entity_centroid( _element ) )
     {
       return get_entity_centroid( _element );
     }
 
     template< typename Element >
-    constexpr auto get_centroid_impl( const Element &_element, overload_priority< 0 >  )
-      -> decltype( _element.centroid() )
+    constexpr KOKKOS_INLINE_FUNCTION auto get_centroid_impl( const Element &_element,
+                                                             overload_priority< 0 > ) -> decltype( _element.centroid() )
     {
       return _element.centroid();
     }
 
-    template< typename Element >
-    constexpr auto get_centroid( const Element &_element )
+    template< typename Element > constexpr KOKKOS_INLINE_FUNCTION auto get_centroid( const Element &_element )
     {
       return get_centroid_impl( _element, overload_priority< 1 >{} );
     }
 
     template< typename Element >
-    constexpr auto get_global_id_impl( const Element &_element, overload_priority< 1 > )
+    constexpr KOKKOS_INLINE_FUNCTION auto get_global_id_impl( const Element &_element, overload_priority< 1 > )
       -> decltype( get_entity_global_id( _element ) )
     {
       return get_entity_global_id( _element );
     }
 
     template< typename Element >
-    constexpr auto get_global_id_impl( const Element &_element, overload_priority< 0 >  )
-      -> decltype( _element.global_id() )
+    constexpr KOKKOS_INLINE_FUNCTION auto
+      get_global_id_impl( const Element &_element, overload_priority< 0 > ) -> decltype( _element.global_id() )
     {
       return _element.global_id();
     }
 
-    template< typename Element >
-    constexpr auto get_global_id( const Element &_element )
+    template< typename Element > constexpr KOKKOS_INLINE_FUNCTION auto get_global_id( const Element &_element )
     {
       return get_global_id_impl( _element, overload_priority< 1 >{} );
     }

--- a/src/bvh/traits.hpp
+++ b/src/bvh/traits.hpp
@@ -33,21 +33,25 @@
 #ifndef INC_BVH_TRAITS_HPP
 #define INC_BVH_TRAITS_HPP
 
+#include <Kokkos_Macros.hpp>
+
+#include <type_traits>
+
 namespace bvh
 {
   template< typename... >
   using void_t = void;
-  
+
   template< unsigned N >
   struct overload_priority
     : overload_priority< N - 1 >
   {
   };
-  
+
   template<>
   struct overload_priority< 0 >
   {};
-  
+
   namespace detail
   {
     template< typename Element >
@@ -56,79 +60,79 @@ namespace bvh
     {
       return get_entity_kdop( _element );
     }
-  
+
     template< typename Element >
     constexpr auto get_kdop_impl( const Element &_element, overload_priority< 0 > )
       -> decltype( _element.kdop() )
     {
       return _element.kdop();
     }
-    
+
     template< typename Element >
     constexpr auto get_kdop( const Element &_element )
     {
       return get_kdop_impl( _element, overload_priority< 1 >{} );
     }
-  
+
     template< typename Element >
     constexpr auto get_centroid_impl( const Element &_element, overload_priority< 1 > )
       -> decltype( get_entity_centroid( _element ) )
     {
       return get_entity_centroid( _element );
     }
-  
+
     template< typename Element >
     constexpr auto get_centroid_impl( const Element &_element, overload_priority< 0 >  )
       -> decltype( _element.centroid() )
     {
       return _element.centroid();
     }
-  
+
     template< typename Element >
     constexpr auto get_centroid( const Element &_element )
     {
       return get_centroid_impl( _element, overload_priority< 1 >{} );
     }
-  
+
     template< typename Element >
     constexpr auto get_global_id_impl( const Element &_element, overload_priority< 1 > )
       -> decltype( get_entity_global_id( _element ) )
     {
       return get_entity_global_id( _element );
     }
-  
+
     template< typename Element >
     constexpr auto get_global_id_impl( const Element &_element, overload_priority< 0 >  )
       -> decltype( _element.global_id() )
     {
       return _element.global_id();
     }
-  
+
     template< typename Element >
     constexpr auto get_global_id( const Element &_element )
     {
       return get_global_id_impl( _element, overload_priority< 1 >{} );
     }
   }
-  
+
   template< typename Element >
   struct element_traits
   {
     using kdop_type = std::remove_cv_t< std::remove_reference_t< decltype( detail::get_kdop( std::declval< Element >() ) ) > >;
     using centroid_type = std::remove_cv_t< std::remove_reference_t< decltype( detail::get_centroid( std::declval< Element >() ) ) > >;
     using global_id_type = std::remove_cv_t< std::remove_reference_t< decltype( detail::get_global_id( std::declval< Element >() ) ) > >;
-    
-    static constexpr kdop_type get_kdop( const Element &_element )
+
+    static constexpr KOKKOS_INLINE_FUNCTION kdop_type get_kdop( const Element &_element )
     {
       return detail::get_kdop( _element );
     }
-    
-    static constexpr centroid_type get_centroid( const Element &_element )
+
+    static constexpr KOKKOS_INLINE_FUNCTION centroid_type get_centroid( const Element &_element )
     {
       return detail::get_centroid( _element );
     }
-    
-    static constexpr global_id_type get_global_id( const Element &_element )
+
+    static constexpr KOKKOS_INLINE_FUNCTION global_id_type get_global_id( const Element &_element )
     {
       return detail::get_global_id( _element );
     }

--- a/src/bvh/util/array.hpp
+++ b/src/bvh/util/array.hpp
@@ -39,8 +39,7 @@
 
 namespace bvh
 {
-  template< typename T, std::size_t N >
-  using array = Kokkos::Array< T, N >;
+  template< typename T, std::size_t N > using array = Kokkos::Array< T, N >;
 }
 
 #endif  // INC_BVH_UTIL_ARRAY_HPP

--- a/src/bvh/util/array.hpp
+++ b/src/bvh/util/array.hpp
@@ -35,12 +35,12 @@
 
 #include "attributes.hpp"
 
-#include <array>
+#include <Kokkos_Array.hpp>
 
 namespace bvh
 {
   template< typename T, std::size_t N >
-  using array = std::array< T, N >;
+  using array = Kokkos::Array< T, N >;
 }
 
 #endif  // INC_BVH_UTIL_ARRAY_HPP

--- a/src/bvh/util/bits.hpp
+++ b/src/bvh/util/bits.hpp
@@ -86,9 +86,9 @@ namespace bvh
   }
 
   template < typename T >
-  inline T clz( T _val )
+  KOKKOS_INLINE_FUNCTION T clz( T _val )
   {
-    return Kokkos::countl_zero( _val );
+    return Kokkos::Experimental::countl_zero_builtin( _val );
   }
 
   inline int bsr( unsigned long _val )

--- a/src/bvh/util/bits.hpp
+++ b/src/bvh/util/bits.hpp
@@ -55,8 +55,8 @@ namespace bvh
 #endif
     return t;
   }
-  template< typename T, unsigned char V >
-  T fill()
+
+  template< typename T, unsigned char V > KOKKOS_INLINE_FUNCTION T fill()
   {
 #ifdef __GNUC__
     T t;

--- a/src/bvh/util/bits.hpp
+++ b/src/bvh/util/bits.hpp
@@ -56,7 +56,8 @@ namespace bvh
     return t;
   }
 
-  template< typename T, unsigned char V > KOKKOS_INLINE_FUNCTION T fill()
+  template< typename T, unsigned char V >
+  KOKKOS_INLINE_FUNCTION T fill()
   {
 #ifdef __GNUC__
     T t;

--- a/src/bvh/util/kokkos.hpp
+++ b/src/bvh/util/kokkos.hpp
@@ -70,6 +70,10 @@ namespace bvh
   template< typename T >
   using unmanaged_view = Kokkos::View< T, primary_execution_space::array_layout, primary_execution_space,
                                        Kokkos::MemoryTraits< Kokkos::Unmanaged > >;
+
+  template< typename T >
+  using unmanaged_host_view = Kokkos::View< T, primary_execution_space::array_layout, host_execution_space,
+                                            Kokkos::MemoryTraits< Kokkos::Unmanaged > >;
 }
 
 #endif  // INC_BVH_UTIL_KOKKOS_HPP

--- a/src/bvh/util/kokkos.hpp
+++ b/src/bvh/util/kokkos.hpp
@@ -66,6 +66,10 @@ namespace bvh
 
   template< typename T >
   using single_host_view = host_view< T >;
+
+  template< typename T >
+  using unmanaged_view = Kokkos::View< T, primary_execution_space::array_layout, primary_execution_space,
+                                       Kokkos::MemoryTraits< Kokkos::Unmanaged > >;
 }
 
 #endif  // INC_BVH_UTIL_KOKKOS_HPP

--- a/src/bvh/util/sort.hpp
+++ b/src/bvh/util/sort.hpp
@@ -33,6 +33,7 @@
 #ifndef INC_BVH_UTIL_SORT_HPP
 #define INC_BVH_UTIL_SORT_HPP
 
+#include <Kokkos_Core.hpp>
 #include <cstdint>
 #include <cstdlib>
 
@@ -122,9 +123,18 @@ namespace bvh
         m_bits( i ) = ~h & 0x1;
         m_scan( i ) = m_bits( i );
       } );
+      // Kokkos::fence();
 
       prefix_sum( m_scan );
-      Kokkos::parallel_for( n, KOKKOS_CLASS_LAMBDA ( int i ){
+      // Kokkos::fence();
+
+      Kokkos::parallel_for( n, KOKKOS_CLASS_LAMBDA( int i ) {
+        // this seems to work fine
+        // printf("i: %d\t num_bits: %d\t _shift: %d\t \n",
+        // i,
+        // static_cast<int>(num_bits),
+        // static_cast<int>(_shift));
+
         const auto total = m_scan( n - 1 ) + m_bits( n - 1 );
 
         auto t = i - m_scan( i ) + total;
@@ -132,6 +142,7 @@ namespace bvh
         m_index_scratch( new_idx ) = _indices( i );
         m_scratch( new_idx ) = _hashes( i );
       } );
+      // Kokkos::fence();
     }
 
   private:

--- a/src/bvh/util/sort.hpp
+++ b/src/bvh/util/sort.hpp
@@ -117,15 +117,14 @@ namespace bvh
     void step( view< T * > _hashes, view< IndexType * > _indices, std::uint32_t _shift )
     {
       const auto n = _hashes.extent( 0 );
-      auto range_policy = Kokkos::RangePolicy<>( 0, n );
-      Kokkos::parallel_for( range_policy, [this, _hashes, _shift] KOKKOS_FUNCTION ( int i ){
+      Kokkos::parallel_for( n, KOKKOS_CLASS_LAMBDA ( int i ){
         auto h = _hashes( i ) >> _shift;
         m_bits( i ) = ~h & 0x1;
         m_scan( i ) = m_bits( i );
       } );
 
       prefix_sum( m_scan );
-      Kokkos::parallel_for( range_policy, [this, _hashes, _indices, n] KOKKOS_FUNCTION ( int i ){
+      Kokkos::parallel_for( n, KOKKOS_CLASS_LAMBDA ( int i ){
         const auto total = m_scan( n - 1 ) + m_bits( n - 1 );
 
         auto t = i - m_scan( i ) + total;

--- a/src/bvh/util/sort.hpp
+++ b/src/bvh/util/sort.hpp
@@ -33,7 +33,6 @@
 #ifndef INC_BVH_UTIL_SORT_HPP
 #define INC_BVH_UTIL_SORT_HPP
 
-#include <Kokkos_Core.hpp>
 #include <cstdint>
 #include <cstdlib>
 
@@ -123,18 +122,9 @@ namespace bvh
         m_bits( i ) = ~h & 0x1;
         m_scan( i ) = m_bits( i );
       } );
-      // Kokkos::fence();
 
       prefix_sum( m_scan );
-      // Kokkos::fence();
-
-      Kokkos::parallel_for( n, KOKKOS_CLASS_LAMBDA( int i ) {
-        // this seems to work fine
-        // printf("i: %d\t num_bits: %d\t _shift: %d\t \n",
-        // i,
-        // static_cast<int>(num_bits),
-        // static_cast<int>(_shift));
-
+      Kokkos::parallel_for( n, KOKKOS_CLASS_LAMBDA ( int i ){
         const auto total = m_scan( n - 1 ) + m_bits( n - 1 );
 
         auto t = i - m_scan( i ) + total;
@@ -142,7 +132,6 @@ namespace bvh
         m_index_scratch( new_idx ) = _indices( i );
         m_scratch( new_idx ) = _hashes( i );
       } );
-      // Kokkos::fence();
     }
 
   private:

--- a/src/bvh/util/span.hpp
+++ b/src/bvh/util/span.hpp
@@ -37,6 +37,7 @@
 #include <type_traits>
 #include "assert.hpp"
 #include <array>
+#include <Kokkos_Macros.hpp>
 #include "../range.hpp"
 
 namespace bvh
@@ -174,7 +175,7 @@ namespace bvh
     constexpr index_type size_bytes() const noexcept { return m_count * sizeof( element_type ); }
     constexpr bool empty() const noexcept { return m_count == 0; }
 
-    constexpr reference operator[]( index_type _idx ) const
+    constexpr KOKKOS_INLINE_FUNCTION reference operator[]( index_type _idx ) const
     {
       BVH_ASSERT( _idx < m_count );
       return m_data[_idx];

--- a/src/bvh/util/span.hpp
+++ b/src/bvh/util/span.hpp
@@ -38,6 +38,7 @@
 #include "assert.hpp"
 #include <array>
 #include <Kokkos_Macros.hpp>
+#include <Kokkos_Array.hpp>
 #include "../range.hpp"
 
 namespace bvh
@@ -94,25 +95,25 @@ namespace bvh
     static constexpr ptrdiff_t extent = Extent;
 
     template< typename = std::enable_if_t< ( extent == 0 ) || ( extent == dynamic_extent() ) > >
-    constexpr span() noexcept
+    constexpr KOKKOS_INLINE_FUNCTION span() noexcept
       : m_data( nullptr ), m_count( 0 )
     {
 
     }
 
-    constexpr span( pointer _ptr, index_type _count )
+    constexpr KOKKOS_INLINE_FUNCTION span( pointer _ptr, index_type _count )
       : m_data( _ptr ), m_count( _count )
     {
       BVH_ASSERT( extent == dynamic_extent() || _count == static_cast< index_type >( extent ) );
     }
 
-    constexpr span( pointer _first, pointer _last )
+    constexpr KOKKOS_INLINE_FUNCTION span( pointer _first, pointer _last )
       : span( _first, _last - _first )
     {}
 
     template< std::size_t N,
               typename = std::enable_if_t< extent == dynamic_extent() || N == static_cast< std::size_t >( extent ) > >
-    constexpr span( element_type ( &_arr )[N] ) noexcept : m_data( _arr ),
+    constexpr KOKKOS_INLINE_FUNCTION span( element_type ( &_arr )[N] ) noexcept : m_data( _arr ),
                                                            m_count( N )
     {
 
@@ -129,6 +130,22 @@ namespace bvh
     template< std::size_t N,
               typename = std::enable_if_t< extent == dynamic_extent() || N == static_cast< std::size_t >( extent ) > >
     constexpr span( const std::array< value_type, N > &_arr ) noexcept : m_data( _arr.data() ),
+                                                                         m_count( N )
+    {
+
+    }
+
+    template< std::size_t N,
+              typename = std::enable_if_t< extent == dynamic_extent() || N == static_cast< std::size_t >( extent ) > >
+    constexpr KOKKOS_INLINE_FUNCTION span( Kokkos::Array< value_type, N > &_arr ) noexcept : m_data( _arr.data() ),
+                                                                   m_count( N )
+    {
+
+    }
+
+    template< std::size_t N,
+              typename = std::enable_if_t< extent == dynamic_extent() || N == static_cast< std::size_t >( extent ) > >
+    constexpr KOKKOS_INLINE_FUNCTION span( const Kokkos::Array< value_type, N > &_arr ) noexcept : m_data( _arr.data() ),
                                                                          m_count( N )
     {
 
@@ -161,19 +178,19 @@ namespace bvh
       && ( std::is_same_v< std::remove_const_t< element_type >, U > )
     >
     >
-    constexpr span( const span< U, N > &_other ) noexcept
+    constexpr KOKKOS_INLINE_FUNCTION span( const span< U, N > &_other ) noexcept
       : m_data( _other.data() ),
         m_count( _other.size() )
     {
 
     }
 
-    constexpr span( const span &_other ) noexcept = default;
+    constexpr KOKKOS_DEFAULTED_FUNCTION span( const span &_other ) noexcept = default;
 
-    constexpr pointer data() const noexcept { return m_data; }
-    constexpr index_type size() const noexcept { return m_count; }
-    constexpr index_type size_bytes() const noexcept { return m_count * sizeof( element_type ); }
-    constexpr bool empty() const noexcept { return m_count == 0; }
+    constexpr KOKKOS_INLINE_FUNCTION pointer data() const noexcept { return m_data; }
+    constexpr KOKKOS_INLINE_FUNCTION index_type size() const noexcept { return m_count; }
+    constexpr KOKKOS_INLINE_FUNCTION index_type size_bytes() const noexcept { return m_count * sizeof( element_type ); }
+    constexpr KOKKOS_INLINE_FUNCTION bool empty() const noexcept { return m_count == 0; }
 
     constexpr KOKKOS_INLINE_FUNCTION reference operator[]( index_type _idx ) const
     {
@@ -181,39 +198,39 @@ namespace bvh
       return m_data[_idx];
     }
 
-    constexpr reference operator()( index_type _idx ) const
+    constexpr KOKKOS_INLINE_FUNCTION reference operator()( index_type _idx ) const
     {
       return ( *this )[_idx];
     }
 
     template< std::ptrdiff_t Count >
-    constexpr span< element_type, Count > first() const
+    constexpr KOKKOS_INLINE_FUNCTION span< element_type, Count > first() const
     {
       BVH_ASSERT( ( Count >= 0 ) && ( Count <= m_count ) );
       return span< element_type, Count >( m_data, Count );
     }
 
-    constexpr span< element_type, dynamic_extent() > first( std::ptrdiff_t _count )
+    constexpr KOKKOS_INLINE_FUNCTION span< element_type, dynamic_extent() > first( std::ptrdiff_t _count )
     {
       BVH_ASSERT( ( _count >= 0 ) && ( _count <= m_count ) );
       return span< element_type, dynamic_extent() >( m_data, _count );
     }
 
     template< std::ptrdiff_t Count >
-    constexpr span< element_type, Count > last() const
+    constexpr KOKKOS_INLINE_FUNCTION span< element_type, Count > last() const
     {
       BVH_ASSERT( ( Count >= 0 ) && ( Count <= m_count ) );
       return span< element_type, Count >( m_data + m_count - Count, Count );
     }
 
-    constexpr span< element_type, dynamic_extent() > last( std::ptrdiff_t _count )
+    constexpr KOKKOS_INLINE_FUNCTION span< element_type, dynamic_extent() > last( std::ptrdiff_t _count )
     {
       BVH_ASSERT( ( _count >= 0 ) && ( _count <= m_count ) );
       return span< element_type, dynamic_extent() >( m_data + m_count - _count, _count );
     }
 
     template< std::ptrdiff_t Offset, std::ptrdiff_t Count = dynamic_extent() >
-    constexpr auto subspan() const
+    constexpr KOKKOS_INLINE_FUNCTION auto subspan() const
     {
       BVH_ASSERT( ( Offset >= 0 ) && ( Offset < m_count ) );
       BVH_ASSERT( ( Count >= 0 ) || ( Count == dynamic_extent() ) );
@@ -229,7 +246,7 @@ namespace bvh
       return span< element_type, ext >( m_data + Offset, ( Count == dynamic_extent() ) ? m_count - Offset : Count );
     }
 
-    constexpr auto subspan( std::ptrdiff_t _offset, std::ptrdiff_t _count = dynamic_extent() ) const
+    constexpr KOKKOS_INLINE_FUNCTION auto subspan( std::ptrdiff_t _offset, std::ptrdiff_t _count = dynamic_extent() ) const
     {
       BVH_ASSERT( ( _offset >= 0 ) && ( _offset < m_count ) );
       BVH_ASSERT( ( _count >= 0 ) || ( _count == dynamic_extent() ) );
@@ -237,19 +254,19 @@ namespace bvh
       return span< element_type, dynamic_extent() >( m_data + _offset, ( _count == dynamic_extent() ) ? m_count - _offset : _count );
     }
 
-    constexpr iterator begin() const noexcept { return m_data; }
-    constexpr iterator cbegin() const noexcept { return m_data; }
+    constexpr KOKKOS_INLINE_FUNCTION iterator begin() const noexcept { return m_data; }
+    constexpr KOKKOS_INLINE_FUNCTION iterator cbegin() const noexcept { return m_data; }
 
-    constexpr iterator end() const noexcept { return m_data + m_count; }
-    constexpr iterator cend() const noexcept { return m_data + m_count; }
+    constexpr KOKKOS_INLINE_FUNCTION iterator end() const noexcept { return m_data + m_count; }
+    constexpr KOKKOS_INLINE_FUNCTION iterator cend() const noexcept { return m_data + m_count; }
 
-    constexpr iterator rbegin() const noexcept { return std::make_reverse_iterator( end() ); }
-    constexpr iterator crbegin() const noexcept { return std::make_reverse_iterator( cend() ); }
+    constexpr KOKKOS_INLINE_FUNCTION iterator rbegin() const noexcept { return std::make_reverse_iterator( end() ); }
+    constexpr KOKKOS_INLINE_FUNCTION iterator crbegin() const noexcept { return std::make_reverse_iterator( cend() ); }
 
-    constexpr iterator rend() const noexcept { return std::make_reverse_iterator( begin() ); }
-    constexpr iterator crend() const noexcept { return std::make_reverse_iterator( cbegin() ); }
+    constexpr KOKKOS_INLINE_FUNCTION iterator rend() const noexcept { return std::make_reverse_iterator( begin() ); }
+    constexpr KOKKOS_INLINE_FUNCTION iterator crend() const noexcept { return std::make_reverse_iterator( cbegin() ); }
 
-    /* implicit */ operator range< iterator >() { return range< iterator >( begin(), end() ); }
+    /* implicit */ operator KOKKOS_INLINE_FUNCTION range< iterator >() { return range< iterator >( begin(), end() ); }
 
   private:
 
@@ -260,19 +277,19 @@ namespace bvh
 
 
   template< std::ptrdiff_t Extent = dynamic_extent(), typename T >
-  auto make_span( T *_begin, T *_end )
+  KOKKOS_INLINE_FUNCTION auto make_span( T *_begin, T *_end )
   {
     return span< T, Extent >( _begin, _end );
   }
 
   template< typename Container >
-  auto make_span( Container &_c )
+  KOKKOS_INLINE_FUNCTION auto make_span( Container &_c )
   {
     return span< typename Container::value_type >( _c );
   }
 
   template< typename Container >
-  auto make_const_span( const Container &_c )
+  KOKKOS_INLINE_FUNCTION auto make_const_span( const Container &_c )
   {
     return span< const typename Container::value_type >( _c );
   }

--- a/src/bvh/util/span.hpp
+++ b/src/bvh/util/span.hpp
@@ -95,23 +95,26 @@ namespace bvh
     static constexpr ptrdiff_t extent = Extent;
 
     template< typename = std::enable_if_t< ( extent == 0 ) || ( extent == dynamic_extent() ) > >
-    constexpr KOKKOS_INLINE_FUNCTION span() noexcept : m_data( nullptr ),
-                                                       m_count( 0 )
+    constexpr KOKKOS_INLINE_FUNCTION span() noexcept
+      : m_data( nullptr ), m_count( 0 )
     {
 
     }
 
-    constexpr KOKKOS_INLINE_FUNCTION span( pointer _ptr, index_type _count ) : m_data( _ptr ), m_count( _count )
+    constexpr KOKKOS_INLINE_FUNCTION span( pointer _ptr, index_type _count )
+      : m_data( _ptr ), m_count( _count )
     {
       BVH_ASSERT( extent == dynamic_extent() || _count == static_cast< index_type >( extent ) );
     }
 
-    constexpr KOKKOS_INLINE_FUNCTION span( pointer _first, pointer _last ) : span( _first, _last - _first ) {}
+    constexpr KOKKOS_INLINE_FUNCTION span( pointer _first, pointer _last )
+      : span( _first, _last - _first )
+    {}
 
     template< std::size_t N,
               typename = std::enable_if_t< extent == dynamic_extent() || N == static_cast< std::size_t >( extent ) > >
     constexpr KOKKOS_INLINE_FUNCTION span( element_type ( &_arr )[N] ) noexcept : m_data( _arr ),
-                                                                                  m_count( N )
+                                                           m_count( N )
     {
 
     }
@@ -134,17 +137,19 @@ namespace bvh
 
     template< std::size_t N,
               typename = std::enable_if_t< extent == dynamic_extent() || N == static_cast< std::size_t >( extent ) > >
-    constexpr KOKKOS_INLINE_FUNCTION span( Kokkos::Array< value_type, N > &_arr ) noexcept
-      : m_data( _arr.data() ),
-        m_count( N )
-    {}
+    constexpr KOKKOS_INLINE_FUNCTION span( Kokkos::Array< value_type, N > &_arr ) noexcept : m_data( _arr.data() ),
+                                                                   m_count( N )
+    {
+
+    }
 
     template< std::size_t N,
               typename = std::enable_if_t< extent == dynamic_extent() || N == static_cast< std::size_t >( extent ) > >
-    constexpr KOKKOS_INLINE_FUNCTION span( const Kokkos::Array< value_type, N > &_arr ) noexcept
-      : m_data( _arr.data() ),
-        m_count( N )
-    {}
+    constexpr KOKKOS_INLINE_FUNCTION span( const Kokkos::Array< value_type, N > &_arr ) noexcept : m_data( _arr.data() ),
+                                                                         m_count( N )
+    {
+
+    }
 
     template< typename Container, typename = std::enable_if_t<
       !std::is_array< Container >::value
@@ -168,9 +173,11 @@ namespace bvh
       : m_data( _container.data() ), m_count( _container.size() )
     {}
 
-    template< typename U, std::ptrdiff_t N,
-              typename = std::enable_if_t< ( extent == dynamic_extent() || N == extent )
-                                           && ( std::is_same_v< std::remove_const_t< element_type >, U > ) > >
+    template< typename U, std::ptrdiff_t N, typename = std::enable_if_t<
+      ( extent == dynamic_extent() || N == extent )
+      && ( std::is_same_v< std::remove_const_t< element_type >, U > )
+    >
+    >
     constexpr KOKKOS_INLINE_FUNCTION span( const span< U, N > &_other ) noexcept
       : m_data( _other.data() ),
         m_count( _other.size() )
@@ -181,11 +188,8 @@ namespace bvh
     constexpr KOKKOS_DEFAULTED_FUNCTION span( const span &_other ) noexcept = default;
 
     constexpr KOKKOS_INLINE_FUNCTION pointer data() const noexcept { return m_data; }
-
     constexpr KOKKOS_INLINE_FUNCTION index_type size() const noexcept { return m_count; }
-
     constexpr KOKKOS_INLINE_FUNCTION index_type size_bytes() const noexcept { return m_count * sizeof( element_type ); }
-
     constexpr KOKKOS_INLINE_FUNCTION bool empty() const noexcept { return m_count == 0; }
 
     constexpr KOKKOS_INLINE_FUNCTION reference operator[]( index_type _idx ) const
@@ -194,9 +198,13 @@ namespace bvh
       return m_data[_idx];
     }
 
-    constexpr KOKKOS_INLINE_FUNCTION reference operator()( index_type _idx ) const { return ( *this )[_idx]; }
+    constexpr KOKKOS_INLINE_FUNCTION reference operator()( index_type _idx ) const
+    {
+      return ( *this )[_idx];
+    }
 
-    template< std::ptrdiff_t Count > constexpr KOKKOS_INLINE_FUNCTION span< element_type, Count > first() const
+    template< std::ptrdiff_t Count >
+    constexpr KOKKOS_INLINE_FUNCTION span< element_type, Count > first() const
     {
       BVH_ASSERT( ( Count >= 0 ) && ( Count <= m_count ) );
       return span< element_type, Count >( m_data, Count );
@@ -208,7 +216,8 @@ namespace bvh
       return span< element_type, dynamic_extent() >( m_data, _count );
     }
 
-    template< std::ptrdiff_t Count > constexpr KOKKOS_INLINE_FUNCTION span< element_type, Count > last() const
+    template< std::ptrdiff_t Count >
+    constexpr KOKKOS_INLINE_FUNCTION span< element_type, Count > last() const
     {
       BVH_ASSERT( ( Count >= 0 ) && ( Count <= m_count ) );
       return span< element_type, Count >( m_data + m_count - Count, Count );
@@ -237,8 +246,7 @@ namespace bvh
       return span< element_type, ext >( m_data + Offset, ( Count == dynamic_extent() ) ? m_count - Offset : Count );
     }
 
-    constexpr KOKKOS_INLINE_FUNCTION auto subspan( std::ptrdiff_t _offset,
-                                                   std::ptrdiff_t _count = dynamic_extent() ) const
+    constexpr KOKKOS_INLINE_FUNCTION auto subspan( std::ptrdiff_t _offset, std::ptrdiff_t _count = dynamic_extent() ) const
     {
       BVH_ASSERT( ( _offset >= 0 ) && ( _offset < m_count ) );
       BVH_ASSERT( ( _count >= 0 ) || ( _count == dynamic_extent() ) );
@@ -247,22 +255,18 @@ namespace bvh
     }
 
     constexpr KOKKOS_INLINE_FUNCTION iterator begin() const noexcept { return m_data; }
-
     constexpr KOKKOS_INLINE_FUNCTION iterator cbegin() const noexcept { return m_data; }
 
     constexpr KOKKOS_INLINE_FUNCTION iterator end() const noexcept { return m_data + m_count; }
-
     constexpr KOKKOS_INLINE_FUNCTION iterator cend() const noexcept { return m_data + m_count; }
 
     constexpr KOKKOS_INLINE_FUNCTION iterator rbegin() const noexcept { return std::make_reverse_iterator( end() ); }
-
     constexpr KOKKOS_INLINE_FUNCTION iterator crbegin() const noexcept { return std::make_reverse_iterator( cend() ); }
 
     constexpr KOKKOS_INLINE_FUNCTION iterator rend() const noexcept { return std::make_reverse_iterator( begin() ); }
-
     constexpr KOKKOS_INLINE_FUNCTION iterator crend() const noexcept { return std::make_reverse_iterator( cbegin() ); }
 
-    /* implicit */ KOKKOS_INLINE_FUNCTION operator range< iterator >() { return range< iterator >( begin(), end() ); }
+    /* implicit */ operator KOKKOS_INLINE_FUNCTION range< iterator >() { return range< iterator >( begin(), end() ); }
 
   private:
 
@@ -276,12 +280,14 @@ namespace bvh
     return span< T, Extent >( _begin, _end );
   }
 
-  template< typename Container > KOKKOS_INLINE_FUNCTION auto make_span( Container &_c )
+  template< typename Container >
+  KOKKOS_INLINE_FUNCTION auto make_span( Container &_c )
   {
     return span< typename Container::value_type >( _c );
   }
 
-  template< typename Container > KOKKOS_INLINE_FUNCTION auto make_const_span( const Container &_c )
+  template< typename Container >
+  KOKKOS_INLINE_FUNCTION auto make_const_span( const Container &_c )
   {
     return span< const typename Container::value_type >( _c );
   }

--- a/src/bvh/util/span.hpp
+++ b/src/bvh/util/span.hpp
@@ -38,7 +38,6 @@
 #include "assert.hpp"
 #include <array>
 #include "../range.hpp"
-#include "../type_traits.hpp"
 
 namespace bvh
 {
@@ -110,23 +109,26 @@ namespace bvh
       : span( _first, _last - _first )
     {}
 
-    template< std::size_t N, typename = std::enable_if_t< extent == dynamic_extent() || N == extent > >
-    constexpr span( element_type ( &_arr )[N] ) noexcept
-      : m_data( _arr ), m_count( N )
+    template< std::size_t N,
+              typename = std::enable_if_t< extent == dynamic_extent() || N == static_cast< std::size_t >( extent ) > >
+    constexpr span( element_type ( &_arr )[N] ) noexcept : m_data( _arr ),
+                                                           m_count( N )
     {
 
     }
 
-    template< std::size_t N, typename = std::enable_if_t< extent == dynamic_extent() || N == extent > >
-    constexpr span( std::array< value_type, N > &_arr ) noexcept
-      : m_data( _arr.data() ), m_count( N )
+    template< std::size_t N,
+              typename = std::enable_if_t< extent == dynamic_extent() || N == static_cast< std::size_t >( extent ) > >
+    constexpr span( std::array< value_type, N > &_arr ) noexcept : m_data( _arr.data() ),
+                                                                   m_count( N )
     {
 
     }
 
-    template< std::size_t N, typename = std::enable_if_t< extent == dynamic_extent() || N == extent > >
-    constexpr span( const std::array< value_type, N > &_arr ) noexcept
-      : m_data( _arr.data() ), m_count( N )
+    template< std::size_t N,
+              typename = std::enable_if_t< extent == dynamic_extent() || N == static_cast< std::size_t >( extent ) > >
+    constexpr span( const std::array< value_type, N > &_arr ) noexcept : m_data( _arr.data() ),
+                                                                         m_count( N )
     {
 
     }

--- a/src/bvh/util/span.hpp
+++ b/src/bvh/util/span.hpp
@@ -262,7 +262,7 @@ namespace bvh
 
     constexpr KOKKOS_INLINE_FUNCTION iterator crend() const noexcept { return std::make_reverse_iterator( cbegin() ); }
 
-    /* implicit */ operator KOKKOS_INLINE_FUNCTION range< iterator >() { return range< iterator >( begin(), end() ); }
+    /* implicit */ KOKKOS_INLINE_FUNCTION operator range< iterator >() { return range< iterator >( begin(), end() ); }
 
   private:
 

--- a/src/bvh/util/span.hpp
+++ b/src/bvh/util/span.hpp
@@ -266,7 +266,7 @@ namespace bvh
     constexpr KOKKOS_INLINE_FUNCTION iterator rend() const noexcept { return std::make_reverse_iterator( begin() ); }
     constexpr KOKKOS_INLINE_FUNCTION iterator crend() const noexcept { return std::make_reverse_iterator( cbegin() ); }
 
-    /* implicit */ operator KOKKOS_INLINE_FUNCTION range< iterator >() { return range< iterator >( begin(), end() ); }
+    /* implicit */ constexpr KOKKOS_INLINE_FUNCTION operator range< iterator >() { return range< iterator >( begin(), end() ); }
 
   private:
 

--- a/src/bvh/util/span.hpp
+++ b/src/bvh/util/span.hpp
@@ -95,26 +95,23 @@ namespace bvh
     static constexpr ptrdiff_t extent = Extent;
 
     template< typename = std::enable_if_t< ( extent == 0 ) || ( extent == dynamic_extent() ) > >
-    constexpr KOKKOS_INLINE_FUNCTION span() noexcept
-      : m_data( nullptr ), m_count( 0 )
+    constexpr KOKKOS_INLINE_FUNCTION span() noexcept : m_data( nullptr ),
+                                                       m_count( 0 )
     {
 
     }
 
-    constexpr KOKKOS_INLINE_FUNCTION span( pointer _ptr, index_type _count )
-      : m_data( _ptr ), m_count( _count )
+    constexpr KOKKOS_INLINE_FUNCTION span( pointer _ptr, index_type _count ) : m_data( _ptr ), m_count( _count )
     {
       BVH_ASSERT( extent == dynamic_extent() || _count == static_cast< index_type >( extent ) );
     }
 
-    constexpr KOKKOS_INLINE_FUNCTION span( pointer _first, pointer _last )
-      : span( _first, _last - _first )
-    {}
+    constexpr KOKKOS_INLINE_FUNCTION span( pointer _first, pointer _last ) : span( _first, _last - _first ) {}
 
     template< std::size_t N,
               typename = std::enable_if_t< extent == dynamic_extent() || N == static_cast< std::size_t >( extent ) > >
     constexpr KOKKOS_INLINE_FUNCTION span( element_type ( &_arr )[N] ) noexcept : m_data( _arr ),
-                                                           m_count( N )
+                                                                                  m_count( N )
     {
 
     }
@@ -137,19 +134,17 @@ namespace bvh
 
     template< std::size_t N,
               typename = std::enable_if_t< extent == dynamic_extent() || N == static_cast< std::size_t >( extent ) > >
-    constexpr KOKKOS_INLINE_FUNCTION span( Kokkos::Array< value_type, N > &_arr ) noexcept : m_data( _arr.data() ),
-                                                                   m_count( N )
-    {
-
-    }
+    constexpr KOKKOS_INLINE_FUNCTION span( Kokkos::Array< value_type, N > &_arr ) noexcept
+      : m_data( _arr.data() ),
+        m_count( N )
+    {}
 
     template< std::size_t N,
               typename = std::enable_if_t< extent == dynamic_extent() || N == static_cast< std::size_t >( extent ) > >
-    constexpr KOKKOS_INLINE_FUNCTION span( const Kokkos::Array< value_type, N > &_arr ) noexcept : m_data( _arr.data() ),
-                                                                         m_count( N )
-    {
-
-    }
+    constexpr KOKKOS_INLINE_FUNCTION span( const Kokkos::Array< value_type, N > &_arr ) noexcept
+      : m_data( _arr.data() ),
+        m_count( N )
+    {}
 
     template< typename Container, typename = std::enable_if_t<
       !std::is_array< Container >::value
@@ -173,11 +168,9 @@ namespace bvh
       : m_data( _container.data() ), m_count( _container.size() )
     {}
 
-    template< typename U, std::ptrdiff_t N, typename = std::enable_if_t<
-      ( extent == dynamic_extent() || N == extent )
-      && ( std::is_same_v< std::remove_const_t< element_type >, U > )
-    >
-    >
+    template< typename U, std::ptrdiff_t N,
+              typename = std::enable_if_t< ( extent == dynamic_extent() || N == extent )
+                                           && ( std::is_same_v< std::remove_const_t< element_type >, U > ) > >
     constexpr KOKKOS_INLINE_FUNCTION span( const span< U, N > &_other ) noexcept
       : m_data( _other.data() ),
         m_count( _other.size() )
@@ -188,8 +181,11 @@ namespace bvh
     constexpr KOKKOS_DEFAULTED_FUNCTION span( const span &_other ) noexcept = default;
 
     constexpr KOKKOS_INLINE_FUNCTION pointer data() const noexcept { return m_data; }
+
     constexpr KOKKOS_INLINE_FUNCTION index_type size() const noexcept { return m_count; }
+
     constexpr KOKKOS_INLINE_FUNCTION index_type size_bytes() const noexcept { return m_count * sizeof( element_type ); }
+
     constexpr KOKKOS_INLINE_FUNCTION bool empty() const noexcept { return m_count == 0; }
 
     constexpr KOKKOS_INLINE_FUNCTION reference operator[]( index_type _idx ) const
@@ -198,13 +194,9 @@ namespace bvh
       return m_data[_idx];
     }
 
-    constexpr KOKKOS_INLINE_FUNCTION reference operator()( index_type _idx ) const
-    {
-      return ( *this )[_idx];
-    }
+    constexpr KOKKOS_INLINE_FUNCTION reference operator()( index_type _idx ) const { return ( *this )[_idx]; }
 
-    template< std::ptrdiff_t Count >
-    constexpr KOKKOS_INLINE_FUNCTION span< element_type, Count > first() const
+    template< std::ptrdiff_t Count > constexpr KOKKOS_INLINE_FUNCTION span< element_type, Count > first() const
     {
       BVH_ASSERT( ( Count >= 0 ) && ( Count <= m_count ) );
       return span< element_type, Count >( m_data, Count );
@@ -216,8 +208,7 @@ namespace bvh
       return span< element_type, dynamic_extent() >( m_data, _count );
     }
 
-    template< std::ptrdiff_t Count >
-    constexpr KOKKOS_INLINE_FUNCTION span< element_type, Count > last() const
+    template< std::ptrdiff_t Count > constexpr KOKKOS_INLINE_FUNCTION span< element_type, Count > last() const
     {
       BVH_ASSERT( ( Count >= 0 ) && ( Count <= m_count ) );
       return span< element_type, Count >( m_data + m_count - Count, Count );
@@ -246,7 +237,8 @@ namespace bvh
       return span< element_type, ext >( m_data + Offset, ( Count == dynamic_extent() ) ? m_count - Offset : Count );
     }
 
-    constexpr KOKKOS_INLINE_FUNCTION auto subspan( std::ptrdiff_t _offset, std::ptrdiff_t _count = dynamic_extent() ) const
+    constexpr KOKKOS_INLINE_FUNCTION auto subspan( std::ptrdiff_t _offset,
+                                                   std::ptrdiff_t _count = dynamic_extent() ) const
     {
       BVH_ASSERT( ( _offset >= 0 ) && ( _offset < m_count ) );
       BVH_ASSERT( ( _count >= 0 ) || ( _count == dynamic_extent() ) );
@@ -255,15 +247,19 @@ namespace bvh
     }
 
     constexpr KOKKOS_INLINE_FUNCTION iterator begin() const noexcept { return m_data; }
+
     constexpr KOKKOS_INLINE_FUNCTION iterator cbegin() const noexcept { return m_data; }
 
     constexpr KOKKOS_INLINE_FUNCTION iterator end() const noexcept { return m_data + m_count; }
+
     constexpr KOKKOS_INLINE_FUNCTION iterator cend() const noexcept { return m_data + m_count; }
 
     constexpr KOKKOS_INLINE_FUNCTION iterator rbegin() const noexcept { return std::make_reverse_iterator( end() ); }
+
     constexpr KOKKOS_INLINE_FUNCTION iterator crbegin() const noexcept { return std::make_reverse_iterator( cend() ); }
 
     constexpr KOKKOS_INLINE_FUNCTION iterator rend() const noexcept { return std::make_reverse_iterator( begin() ); }
+
     constexpr KOKKOS_INLINE_FUNCTION iterator crend() const noexcept { return std::make_reverse_iterator( cbegin() ); }
 
     /* implicit */ operator KOKKOS_INLINE_FUNCTION range< iterator >() { return range< iterator >( begin(), end() ); }
@@ -274,22 +270,18 @@ namespace bvh
     index_type m_count;
   };
 
-
-
   template< std::ptrdiff_t Extent = dynamic_extent(), typename T >
   KOKKOS_INLINE_FUNCTION auto make_span( T *_begin, T *_end )
   {
     return span< T, Extent >( _begin, _end );
   }
 
-  template< typename Container >
-  KOKKOS_INLINE_FUNCTION auto make_span( Container &_c )
+  template< typename Container > KOKKOS_INLINE_FUNCTION auto make_span( Container &_c )
   {
     return span< typename Container::value_type >( _c );
   }
 
-  template< typename Container >
-  KOKKOS_INLINE_FUNCTION auto make_const_span( const Container &_c )
+  template< typename Container > KOKKOS_INLINE_FUNCTION auto make_const_span( const Container &_c )
   {
     return span< const typename Container::value_type >( _c );
   }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,8 +43,8 @@ if (NOT BVH_DISABLE_TESTS)
       #PatchTest.cpp
       #PrimitiveTest.cpp
       # bits_test.cpp
-      # hash_test.cpp
-      # sort_test.cpp
+      hash_test.cpp
+      sort_test.cpp
       # SplitTest.cpp
       # UtilTest.cpp
       # math_vec_tests.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,24 +33,24 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 if (NOT BVH_DISABLE_TESTS)
   add_executable(BVHTests
       TestMain.cpp
-      # KDopTest.cpp
-      # TreeTest.cpp
-      # CollisionTest.cpp
-      # IteratorTest.cpp
+      KDopTest.cpp
+      TreeTest.cpp
+      CollisionTest.cpp
+      IteratorTest.cpp
       #BroadphaseTest.cpp
       #NarrowphaseTest.cpp
-      # SerializerTest.cpp
+      SerializerTest.cpp
       #PatchTest.cpp
       #PrimitiveTest.cpp
-      # bits_test.cpp
+      bits_test.cpp
       hash_test.cpp
       sort_test.cpp
-      # SplitTest.cpp
-      # UtilTest.cpp
-      # math_vec_tests.cpp
+      SplitTest.cpp
+      UtilTest.cpp
+      math_vec_tests.cpp
       collision_object_test.cpp
-      # cluster_test.cpp
-      # snapshot_test.cpp
+      cluster_test.cpp
+      snapshot_test.cpp
     )
 
   if (Kokkos_FOUND)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,24 +33,24 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 if (NOT BVH_DISABLE_TESTS)
   add_executable(BVHTests
       TestMain.cpp
-      KDopTest.cpp
-      TreeTest.cpp
-      CollisionTest.cpp
-      IteratorTest.cpp
+      # KDopTest.cpp
+      # TreeTest.cpp
+      # CollisionTest.cpp
+      # IteratorTest.cpp
       #BroadphaseTest.cpp
       #NarrowphaseTest.cpp
-      SerializerTest.cpp
+      # SerializerTest.cpp
       #PatchTest.cpp
       #PrimitiveTest.cpp
-      bits_test.cpp
-      hash_test.cpp
-      sort_test.cpp
-      SplitTest.cpp
-      UtilTest.cpp
-      math_vec_tests.cpp
+      # bits_test.cpp
+      # hash_test.cpp
+      # sort_test.cpp
+      # SplitTest.cpp
+      # UtilTest.cpp
+      # math_vec_tests.cpp
       collision_object_test.cpp
-      cluster_test.cpp
-      snapshot_test.cpp
+      # cluster_test.cpp
+      # snapshot_test.cpp
     )
 
   if (Kokkos_FOUND)

--- a/tests/SerializerTest.cpp
+++ b/tests/SerializerTest.cpp
@@ -138,7 +138,7 @@ TEST_CASE("ghost_msg serialization", "[serializer][collision_object][narrowphase
         for ( std::size_t i = 0; i < 4096; ++i )
           vals.push_back( static_cast< double >( i + 1 ) );
         msg->origin_node = 13;
-        msg->patch_data.resize( vals.size() * sizeof( double ) );
+        Kokkos::resize( msg->patch_data, vals.size() * sizeof( double ) );
         std::memcpy( msg->patch_data.data(), vals.data(), msg->patch_data.size() );
 
         auto han = ::vt::auto_registry::makeAutoHandler< bvh::collision_object_impl::ghost_msg, check_ghost_msg >();
@@ -193,7 +193,7 @@ TEST_CASE("narrowphase_patches collection serialization", "[serializer][collisio
     ::vt::theMsg()->pushEpoch( ep );
 
     auto collection = ::vt::theCollection()->constructCollective< narrowphase_patch_collection_type >(
-      coll_size, []( [[maybe_unused]] vt_index _idx ) {
+      coll_size, []( vt_index _idx ) {
       auto ret = std::make_unique< narrowphase_patch_collection_type >();
       auto k = bvh::bphase_kdop::from_sphere( bvh::m::vec3d{ 17.53, 21.9, 36.0 }, 2.7 );
       bvh::patch<> p( 13, 4096, k, bvh::m::vec3d{ 17.3, 20.6, 33.31 } );
@@ -203,7 +203,7 @@ TEST_CASE("narrowphase_patches collection serialization", "[serializer][collisio
       vals.reserve( 4096 );
       for ( std::size_t i = 0; i < 4096; ++i )
         vals.push_back( static_cast< double >( i + 1 ) );
-      ret->bytes.resize( 4096 * sizeof( double ) );
+      Kokkos::resize( ret->bytes, 4096 * sizeof( double ) );
       std::memcpy( ret->bytes.data(), vals.data(), ret->bytes.size() );
       return ret;
     } );

--- a/tests/SerializerTest.cpp
+++ b/tests/SerializerTest.cpp
@@ -193,7 +193,7 @@ TEST_CASE("narrowphase_patches collection serialization", "[serializer][collisio
     ::vt::theMsg()->pushEpoch( ep );
 
     auto collection = ::vt::theCollection()->constructCollective< narrowphase_patch_collection_type >(
-      coll_size, []( vt_index _idx ) {
+      coll_size, []( [[ maybe_unused ]] vt_index _idx ) {
       auto ret = std::make_unique< narrowphase_patch_collection_type >();
       auto k = bvh::bphase_kdop::from_sphere( bvh::m::vec3d{ 17.53, 21.9, 36.0 }, 2.7 );
       bvh::patch<> p( 13, 4096, k, bvh::m::vec3d{ 17.3, 20.6, 33.31 } );

--- a/tests/SplitTest.cpp
+++ b/tests/SplitTest.cpp
@@ -75,9 +75,9 @@ namespace
     unsigned m_gid;
     bvh::m::vec3d m_centroid;
 
-    const kdop_type &kdop() const noexcept{ return m_kdop; }
-    const bvh::m::vec3d &centroid() const noexcept { return m_centroid; }
-    unsigned global_id() const noexcept { return m_gid; }
+    const KOKKOS_INLINE_FUNCTION kdop_type &kdop() const noexcept{ return m_kdop; }
+    const KOKKOS_INLINE_FUNCTION bvh::m::vec3d &centroid() const noexcept { return m_centroid; }
+    KOKKOS_INLINE_FUNCTION unsigned global_id() const noexcept { return m_gid; }
   };
 }
 
@@ -331,6 +331,7 @@ TEST_CASE("recursive mean splitting 2D elements", "[split]")
 
 }
 
+#ifndef BVH_ENABLE_CUDA
 TEST_CASE("new recursive mean splitting 2D elements", "[split]")
 {
   static constexpr std::size_t Nx = 4, Ny = 3;
@@ -437,3 +438,4 @@ TEST_CASE("new recursive mean splitting 2D elements", "[split]")
     //
   }
 }
+#endif

--- a/tests/TestCommon.hpp
+++ b/tests/TestCommon.hpp
@@ -199,7 +199,7 @@ build_element_grid( int _x, int _y, int _z, std::size_t _base_index = 0, double 
     double z = _origin_shift + _k * dz;
 
     const std::size_t index = _i + _j * _x + _k * _x * _y;
-    assert( index < ret.extent( 0 ) );
+    // assert( index < ret.extent( 0 ) );
     auto &el = ret( index );
     el.setIndex( _base_index + index );
     el.setVertices( bvh::m::vec3d{ x, y, z }, bvh::m::vec3d{ x + dx, y, z }, bvh::m::vec3d{ x + dx, y + dy, z },

--- a/tests/TestCommon.hpp
+++ b/tests/TestCommon.hpp
@@ -60,9 +60,11 @@ public:
   KOKKOS_DEFAULTED_FUNCTION Element &operator=( Element &&_other ) noexcept = default;
 
   KOKKOS_INLINE_FUNCTION auto begin() { return m_vertices.data(); }
+
   KOKKOS_INLINE_FUNCTION auto begin() const { return m_vertices.data(); }
 
   KOKKOS_INLINE_FUNCTION auto end() { return m_vertices.data() + 8; }
+
   KOKKOS_INLINE_FUNCTION auto end() const { return m_vertices.data() + 8; }
 
   KOKKOS_INLINE_FUNCTION bvh::m::vec3d centroid() const
@@ -74,8 +76,7 @@ public:
   };
 
   template< typename... Args >
-  KOKKOS_INLINE_FUNCTION std::enable_if_t< ( sizeof...( Args ) == vertex_count ) >
-  setVertices( Args &&... _args )
+  KOKKOS_INLINE_FUNCTION std::enable_if_t< ( sizeof...( Args ) == vertex_count ) > setVertices( Args &&..._args )
   {
     m_vertices = Kokkos::Array< bvh::m::vec3d, vertex_count >{ std::forward< Args >( _args )... };
     m_bounds = kdop_type::from_vertices( begin(), end() );
@@ -86,6 +87,7 @@ public:
   KOKKOS_INLINE_FUNCTION bvh::span< const bvh::m::vec3d > vertices() const { return m_vertices; }
 
   KOKKOS_INLINE_FUNCTION const kdop_type &kdop() const { return m_bounds; }
+
   KOKKOS_INLINE_FUNCTION std::size_t global_id() const { return m_index; }
 
   friend std::ostream &operator<<( std::ostream &os, const Element &el )
@@ -106,7 +108,6 @@ public:
   {
     if ( _lhs.m_index != _rhs.m_index )
       return false;
-
 
     for ( std::size_t i = 0; i < _lhs.m_vertices.size(); ++i )
       if ( _lhs.vertices()[i] != _rhs.vertices()[i] )
@@ -130,21 +131,20 @@ private:
   kdop_type m_bounds;
 };
 
-
 KOKKOS_INLINE_FUNCTION auto
-get_entity_kdop( const Element &_element )
+  get_entity_kdop( const Element &_element )
 {
   return _element.kdop();
 }
 
 KOKKOS_INLINE_FUNCTION auto
-get_entity_global_id( const Element &_element )
+  get_entity_global_id( const Element &_element )
 {
   return _element.global_id();
 }
 
 KOKKOS_INLINE_FUNCTION auto
-get_entity_centroid( const Element &_element )
+  get_entity_centroid( const Element &_element )
 {
   return _element.centroid();
 }

--- a/tests/TestCommon.hpp
+++ b/tests/TestCommon.hpp
@@ -79,7 +79,7 @@ public:
   KOKKOS_INLINE_FUNCTION std::enable_if_t< ( sizeof...( Args ) == vertex_count ) > setVertices( Args &&..._args )
   {
     m_vertices = Kokkos::Array< bvh::m::vec3d, vertex_count >{ std::forward< Args >( _args )... };
-    m_bounds = kdop_type::from_vertices( begin(), end() );
+    m_bounds = kdop_type::from_vertices( m_vertices );
   }
 
   KOKKOS_INLINE_FUNCTION void setIndex( std::size_t _index ) { m_index = _index; }

--- a/tests/TestCommon.hpp
+++ b/tests/TestCommon.hpp
@@ -33,6 +33,7 @@
 #ifndef INC_TEST_COMMON_HPP
 #define INC_TEST_COMMON_HPP
 
+#include <Kokkos_Macros.hpp>
 #include <bvh/types.hpp>
 #include <catch2/catch.hpp>
 
@@ -41,7 +42,6 @@
 #include <bvh/kdop.hpp>
 #include <bvh/patch.hpp>
 #include <bvh/util/container.hpp>
-#include <numeric>
 #include <random>
 
 
@@ -54,10 +54,10 @@ public:
 
   KOKKOS_INLINE_FUNCTION Element( std::size_t _index = static_cast< std::size_t >( -1 ) ) : m_index( _index ) {};
 
-  KOKKOS_INLINE_FUNCTION Element( const Element &_other ) = default;
-  KOKKOS_INLINE_FUNCTION Element( Element &&_other ) noexcept = default;
-  KOKKOS_INLINE_FUNCTION Element &operator=( const Element &_other ) = default;
-  KOKKOS_INLINE_FUNCTION Element &operator=( Element &&_other ) noexcept = default;
+  KOKKOS_DEFAULTED_FUNCTION Element( const Element &_other ) = default;
+  KOKKOS_DEFAULTED_FUNCTION Element( Element &&_other ) noexcept = default;
+  KOKKOS_DEFAULTED_FUNCTION Element &operator=( const Element &_other ) = default;
+  KOKKOS_DEFAULTED_FUNCTION Element &operator=( Element &&_other ) noexcept = default;
 
   KOKKOS_INLINE_FUNCTION auto begin() { return m_vertices.data(); }
   KOKKOS_INLINE_FUNCTION auto begin() const { return m_vertices.data(); }

--- a/tests/TestCommon.hpp
+++ b/tests/TestCommon.hpp
@@ -203,7 +203,6 @@ build_element_grid( int _x, int _y, int _z, std::size_t _base_index = 0, double 
     double z = _origin_shift + _k * dz;
 
     const std::size_t index = _i + _j * _x + _k * _x * _y;
-    // assert( index < ret.extent( 0 ) );
     auto &el = ret( index );
     el.setIndex( _base_index + index );
     el.setVertices( bvh::m::vec3d{ x, y, z }, bvh::m::vec3d{ x + dx, y, z }, bvh::m::vec3d{ x + dx, y + dy, z },

--- a/tests/collision_object_test.cpp
+++ b/tests/collision_object_test.cpp
@@ -252,8 +252,11 @@ TEST_CASE( "collision_object init", "[vt]")
 
 TEST_CASE( "collision_object broadphase", "[vt]")
 {
-  auto split_method
-    = GENERATE( bvh::split_algorithm::geom_axis, bvh::split_algorithm::ml_geom_axis, bvh::split_algorithm::clustering );
+  auto split_method = GENERATE(
+#ifndef BVH_ENABLE_CUDA
+  bvh::split_algorithm::geom_axis, bvh::split_algorithm::ml_geom_axis,
+#endif
+  bvh::split_algorithm::clustering );
   bvh::collision_world world( 2 );
 
   auto &obj = world.create_collision_object();

--- a/tests/collision_object_test.cpp
+++ b/tests/collision_object_test.cpp
@@ -127,8 +127,11 @@ TEST_CASE( "collision_object init", "[vt]")
   bvh::vt::debug( "{}: bounds: {}\n", ::vt::theContext()->getNode(), bounds );
   auto update_elements = build_element_grid( 2 * od_factor, 3 * od_factor, 2 * od_factor, rank * 12 * od_factor, 10.0 );
 
-  auto split_method
-    = GENERATE( /*bvh::split_algorithm::geom_axis, bvh::split_algorithm::ml_geom_axis,*/ bvh::split_algorithm::clustering );
+  auto split_method = GENERATE(
+#ifndef BVH_ENABLE_CUDA
+    bvh::split_algorithm::geom_axis, bvh::split_algorithm::ml_geom_axis,
+#endif
+    bvh::split_algorithm::clustering );
 
   bvh::vt::debug("{}: od_factor: {} split method: {}\n", ::vt::theContext()->getNode(), od_factor, static_cast< int >( split_method ) );
 

--- a/tests/collision_object_test.cpp
+++ b/tests/collision_object_test.cpp
@@ -252,11 +252,13 @@ TEST_CASE( "collision_object init", "[vt]")
 
 TEST_CASE( "collision_object broadphase", "[vt]")
 {
-  auto split_method = GENERATE(
+  auto split_method
+    = GENERATE(
 #ifndef BVH_ENABLE_CUDA
-  bvh::split_algorithm::geom_axis, bvh::split_algorithm::ml_geom_axis,
+      bvh::split_algorithm::geom_axis,
+      bvh::split_algorithm::ml_geom_axis,
 #endif
-  bvh::split_algorithm::clustering );
+      bvh::split_algorithm::clustering );
   bvh::collision_world world( 2 );
 
   auto &obj = world.create_collision_object();

--- a/tests/collision_object_test.cpp
+++ b/tests/collision_object_test.cpp
@@ -417,7 +417,7 @@ TEST_CASE( "collision_object narrowphase", "[vt]")
                                                   const bvh::broadphase_collision< Element > &_b ) {
       auto res = bvh::narrowphase_result_pair();
       auto numNodes = ::vt::theContext()->getNumNodes();
-      auto numPossibleCollisions = _b.elements.size() * numNodes;
+      auto numPossibleCollisions = _a.elements.extent( 0 ) * numNodes * _b.elements.extent( 0 ) * numNodes;
       res.a = bvh::narrowphase_result( sizeof( detailed_narrowphase_result ), numPossibleCollisions );
       res.b = bvh::narrowphase_result( sizeof( detailed_narrowphase_result ), numPossibleCollisions );
       auto &resa = static_cast< bvh::typed_narrowphase_result< detailed_narrowphase_result > & >( res.a );

--- a/tests/collision_object_test.cpp
+++ b/tests/collision_object_test.cpp
@@ -98,7 +98,7 @@ verify_empty_elements( std::size_t _count )
 
 TEST_CASE( "collision_object init", "[vt]")
 {
-  std::size_t od_factor = GENERATE( 1, 2, 4, 32, 64 );
+  std::size_t od_factor = GENERATE( /*1,*/ 2/*, 4, 32, 64*/ );
   test_od_factor = od_factor;
   bvh::collision_world world( od_factor );
 
@@ -128,7 +128,7 @@ TEST_CASE( "collision_object init", "[vt]")
   auto update_elements = build_element_grid( 2 * od_factor, 3 * od_factor, 2 * od_factor, rank * 12 * od_factor, 10.0 );
 
   auto split_method
-    = GENERATE( bvh::split_algorithm::geom_axis, bvh::split_algorithm::ml_geom_axis, bvh::split_algorithm::clustering );
+    = GENERATE( /*bvh::split_algorithm::geom_axis, bvh::split_algorithm::ml_geom_axis,*/ bvh::split_algorithm::clustering );
 
   bvh::vt::debug("{}: od_factor: {} split method: {}\n", ::vt::theContext()->getNode(), od_factor, static_cast< int >( split_method ) );
 
@@ -376,7 +376,7 @@ void verify_single_narrowphase( const bvh::vt::reducable_vector< detailed_narrow
 TEST_CASE( "collision_object narrowphase", "[vt]")
 {
   auto split_method
-    = GENERATE( bvh::split_algorithm::geom_axis, bvh::split_algorithm::ml_geom_axis, bvh::split_algorithm::clustering );
+    = GENERATE( /*bvh::split_algorithm::geom_axis, bvh::split_algorithm::ml_geom_axis,*/ bvh::split_algorithm::clustering );
 
   bvh::vt::debug("{}: split method: {}\n", ::vt::theContext()->getNode(), static_cast< int >( split_method ) );
 

--- a/tests/collision_object_test.cpp
+++ b/tests/collision_object_test.cpp
@@ -416,8 +416,10 @@ TEST_CASE( "collision_object narrowphase", "[vt]")
     world.set_narrowphase_functor< Element >( []( const bvh::broadphase_collision< Element > &_a,
                                                   const bvh::broadphase_collision< Element > &_b ) {
       auto res = bvh::narrowphase_result_pair();
-      res.a = bvh::narrowphase_result( sizeof( detailed_narrowphase_result ));
-      res.b = bvh::narrowphase_result( sizeof( detailed_narrowphase_result ));
+      auto numNodes = ::vt::theContext()->getNumNodes();
+      auto numPossibleCollisions = _b.elements.size() * numNodes;
+      res.a = bvh::narrowphase_result( sizeof( detailed_narrowphase_result ), numPossibleCollisions );
+      res.b = bvh::narrowphase_result( sizeof( detailed_narrowphase_result ), numPossibleCollisions );
       auto &resa = static_cast< bvh::typed_narrowphase_result< detailed_narrowphase_result > & >( res.a );
 
       REQUIRE( _a.object.id() == 0 );
@@ -586,8 +588,10 @@ TEST_CASE( "collision_object narrowphase three objects", "[vt]" ) {
     world.set_narrowphase_functor< Element >( []( const bvh::broadphase_collision< Element > &_a,
       const bvh::broadphase_collision< Element > &_b ) {
       auto res = bvh::narrowphase_result_pair();
-      res.a = bvh::narrowphase_result( sizeof( detailed_narrowphase_result ));
-      res.b = bvh::narrowphase_result( sizeof( detailed_narrowphase_result ));
+      auto numNodes = ::vt::theContext()->getNumNodes();
+      auto numPossibleCollisions = _a.elements.extent( 0 ) * numNodes * _b.elements.extent( 0 ) * numNodes;
+      res.a = bvh::narrowphase_result( sizeof( detailed_narrowphase_result), numPossibleCollisions );
+      res.b = bvh::narrowphase_result( sizeof( detailed_narrowphase_result), numPossibleCollisions );
       auto &resa = static_cast< bvh::typed_narrowphase_result< detailed_narrowphase_result > & >( res.a );
 
       Kokkos::parallel_for( _b.elements.extent( 0 ), [=, &resa]( int i ) {
@@ -663,8 +667,10 @@ TEST_CASE( "collision_object narrowphase multi-iteration", "[vt]")
       world.set_narrowphase_functor< Element >(
         []( const bvh::broadphase_collision< Element > &_a, const bvh::broadphase_collision< Element > &_b ) {
         auto res = bvh::narrowphase_result_pair();
-        res.a = bvh::narrowphase_result( sizeof( narrowphase_result ));
-        res.b = bvh::narrowphase_result( sizeof( narrowphase_result ));
+        auto numNodes = ::vt::theContext()->getNumNodes();
+        auto numPossibleCollisions = _b.elements.size() * numNodes;
+        res.a = bvh::narrowphase_result( sizeof( narrowphase_result ), numPossibleCollisions );
+        res.b = bvh::narrowphase_result( sizeof( narrowphase_result ), numPossibleCollisions );
         auto &resa = static_cast< bvh::typed_narrowphase_result< narrowphase_result > & >( res.a );
         auto &resb = static_cast< bvh::typed_narrowphase_result< narrowphase_result > & >( res.b );
 
@@ -767,8 +773,10 @@ TEST_CASE( "collision_object narrowphase no overlap multi-iteration", "[vt]")
       world.set_narrowphase_functor< Element >( []( const bvh::broadphase_collision< Element > &_a,
                                                     const bvh::broadphase_collision< Element > &_b ) {
         auto res = bvh::narrowphase_result_pair();
-        res.a = bvh::narrowphase_result( sizeof( narrowphase_result ));
-        res.b = bvh::narrowphase_result( sizeof( narrowphase_result ));
+        auto numNodes = ::vt::theContext()->getNumNodes();
+        auto numPossibleCollisions = _a.elements.extent( 0 ) * numNodes * _b.elements.extent( 0 ) * numNodes;
+        res.a = bvh::narrowphase_result( sizeof( narrowphase_result ), numPossibleCollisions );
+        res.b = bvh::narrowphase_result( sizeof( narrowphase_result ), numPossibleCollisions );
         auto &resa = static_cast< bvh::typed_narrowphase_result< narrowphase_result > & >( res.a );
         auto &resb = static_cast< bvh::typed_narrowphase_result< narrowphase_result > & >( res.b );
 

--- a/tests/collision_object_test.cpp
+++ b/tests/collision_object_test.cpp
@@ -282,8 +282,11 @@ TEST_CASE( "collision_object broadphase", "[vt]")
 
 TEST_CASE( "collision_object multiple broadphase", "[vt]")
 {
-  auto split_method
-    = GENERATE( bvh::split_algorithm::geom_axis, bvh::split_algorithm::ml_geom_axis, bvh::split_algorithm::clustering );
+  auto split_method = GENERATE(
+#ifndef BVH_ENABLE_CUDA
+    bvh::split_algorithm::geom_axis, bvh::split_algorithm::ml_geom_axis,
+#endif
+    bvh::split_algorithm::clustering );
   bvh::collision_world world( 2 );
 
   auto &obj = world.create_collision_object();
@@ -381,8 +384,11 @@ void verify_single_narrowphase( const bvh::vt::reducable_vector< detailed_narrow
 
 TEST_CASE( "collision_object narrowphase", "[vt]")
 {
-  auto split_method
-    = GENERATE( /*bvh::split_algorithm::geom_axis, bvh::split_algorithm::ml_geom_axis,*/ bvh::split_algorithm::clustering );
+  auto split_method = GENERATE(
+#ifndef BVH_ENABLE_CUDA
+    bvh::split_algorithm::geom_axis, bvh::split_algorithm::ml_geom_axis,
+#endif
+    bvh::split_algorithm::clustering );
 
   bvh::vt::debug("{}: split method: {}\n", ::vt::theContext()->getNode(), static_cast< int >( split_method ) );
 
@@ -618,8 +624,11 @@ TEST_CASE( "collision_object narrowphase three objects", "[vt]" ) {
 
 TEST_CASE( "collision_object narrowphase multi-iteration", "[vt]")
 {
-  auto split_method
-    = GENERATE( bvh::split_algorithm::geom_axis, bvh::split_algorithm::ml_geom_axis, bvh::split_algorithm::clustering );
+  auto split_method = GENERATE(
+#ifndef BVH_ENABLE_CUDA
+    bvh::split_algorithm::geom_axis, bvh::split_algorithm::ml_geom_axis,
+#endif
+    bvh::split_algorithm::clustering );
 
   bvh::vt::debug("{}: split method: {}\n", ::vt::theContext()->getNode(), static_cast< int >( split_method ) );
 
@@ -724,8 +733,11 @@ TEST_CASE( "collision_object narrowphase multi-iteration", "[vt]")
 
 TEST_CASE( "collision_object narrowphase no overlap multi-iteration", "[vt]")
 {
-  auto split_method
-    = GENERATE( bvh::split_algorithm::geom_axis, bvh::split_algorithm::ml_geom_axis, bvh::split_algorithm::clustering );
+  auto split_method = GENERATE(
+#ifndef BVH_ENABLE_CUDA
+    bvh::split_algorithm::geom_axis, bvh::split_algorithm::ml_geom_axis,
+#endif
+    bvh::split_algorithm::clustering );
   bvh::collision_world world( 2 );
 
   auto &obj = world.create_collision_object();

--- a/tests/collision_object_test.cpp
+++ b/tests/collision_object_test.cpp
@@ -421,10 +421,11 @@ TEST_CASE( "collision_object narrowphase", "[vt]")
       // Global id of the first patch should be the node from whence it came
       REQUIRE( _a.elements[0].global_id() < static_cast< std::size_t >( ::vt::theContext()->getNumNodes() ) );
 
-      for ( auto &&e: _b.elements ) {
-        REQUIRE( e.global_id() < static_cast< std::size_t >( ::vt::theContext()->getNumNodes() * 12 ) );
+      for ( std::size_t i = 0; i < _b.elements.size(); i++ )
+      {
+        REQUIRE( _b.elements( i ).global_id() < static_cast< std::size_t >( ::vt::theContext()->getNumNodes() * 12 ) );
         resa.emplace_back( detailed_narrowphase_result{ _a.meta.global_id(), _a.elements[0].global_id(),
-                                                        _b.meta.global_id(), e.global_id() } );
+                                                        _b.meta.global_id(), _b.elements( i ).global_id() } );
       }
 
       return res;
@@ -666,8 +667,9 @@ TEST_CASE( "collision_object narrowphase multi-iteration", "[vt]")
                         _a.object.id(), _a.patch_id,
                         _b.object.id(), _b.patch_id );
 
-        for ( auto &&e: _b.elements )
+        for ( std::size_t i = 0; i < _b.elements.size(); i++ )
         {
+          auto &e = _b.elements( i );
           CHECK( e.global_id() < static_cast< std::size_t >( ::vt::theContext()->getNumNodes() * 12 ) );
           bvh::vt::debug("{}: intersect result ({}, {}, {}) with ({}, {}, {})\n",
                          ::vt::theContext()->getNode(),
@@ -762,7 +764,9 @@ TEST_CASE( "collision_object narrowphase no overlap multi-iteration", "[vt]")
         // Global id of the first patch should be the node from whence it came
         REQUIRE( _a.elements[0].global_id() < static_cast< std::size_t >( ::vt::theContext()->getNumNodes() ) );
 
-        for ( auto &&e: _b.elements ) {
+        for ( std::size_t i = 0; i < _b.elements.size(); i++ )
+        {
+          auto &e = _b.elements( i );
           CHECK( e.global_id() < static_cast< std::size_t >( ::vt::theContext()->getNumNodes() * 12 ) );
           resa.emplace_back( e.global_id());
           resb.emplace_back( _a.elements[0].global_id());

--- a/tests/collision_object_test.cpp
+++ b/tests/collision_object_test.cpp
@@ -721,9 +721,6 @@ TEST_CASE( "collision_object narrowphase multi-iteration", "[vt]")
                         _a.object.id(), _a.patch_id,
                         _b.object.id(), _b.patch_id );
 
-        const auto aid = _a.meta.global_id();
-        const auto bid = _b.meta.global_id();
-
         Kokkos::parallel_for( _b.elements.extent( 0 ), KOKKOS_LAMBDA( int _i ) {
           auto ra = resa;
           auto rb = resb;

--- a/tests/collision_object_test.cpp
+++ b/tests/collision_object_test.cpp
@@ -31,7 +31,10 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "TestCommon.hpp"
+#include "bvh/collision_query.hpp"
 #include "bvh/types.hpp"
+#include <Kokkos_Core.hpp>
+#include <Kokkos_Core_fwd.hpp>
 #include <bvh/vt/helpers.hpp>
 #include <bvh/collision_object.hpp>
 #include <bvh/collision_world.hpp>
@@ -86,7 +89,7 @@ void verify_num_elements( std::size_t _count )
 {
   bvh::vt::debug("{}: count: {}\n", ::vt::theContext()->getNode(), _count );
   // Cube test_od_factor because each dimension is multiplied...
-  REQUIRE( _count == 12 * ::vt::theContext()->getNumNodes() * test_od_factor * test_od_factor * test_od_factor );
+  REQUIRE( _count == 12 * ::vt::theContext()->getNumNodes() * test_od_factor );
 };
 
 void
@@ -98,14 +101,14 @@ verify_empty_elements( std::size_t _count )
 
 TEST_CASE( "collision_object init", "[vt]")
 {
-  std::size_t od_factor = GENERATE( /*1,*/ 2/*, 4, 32, 64*/ );
+  std::size_t od_factor = GENERATE( 1, 2, 4, 32, 64 );
   test_od_factor = od_factor;
   bvh::collision_world world( od_factor );
 
   auto &obj = world.create_collision_object();
 
   auto rank = ::vt::theContext()->getNode();
-  auto elements = build_element_grid( 2 * od_factor, 3 * od_factor, 2 * od_factor, rank * 12 * od_factor );
+  auto elements = build_element_grid( 2 * od_factor, 3, 2, rank * 12 * od_factor );
   const std::array bound_vers{ bvh::m::vec3d{ 0.0, 0.0, 0.0 },
                                bvh::m::vec3d{ 0.0, 0.0, 1.0 },
                                bvh::m::vec3d{ 0.0, 1.0, 0.0 },
@@ -125,7 +128,7 @@ TEST_CASE( "collision_object init", "[vt]")
                                        bvh::m::vec3d{ 11.0, 11.0, 11.0 } };
   const auto update_bounds = Element::kdop_type::from_vertices( update_bounds_vers.begin(), update_bounds_vers.end() );
   bvh::vt::debug( "{}: bounds: {}\n", ::vt::theContext()->getNode(), bounds );
-  auto update_elements = build_element_grid( 2 * od_factor, 3 * od_factor, 2 * od_factor, rank * 12 * od_factor, 10.0 );
+  auto update_elements = build_element_grid( 2 * od_factor, 3, 2, rank * 12 * od_factor, 10.0 );
 
   auto split_method = GENERATE(
 #ifndef BVH_ENABLE_CUDA
@@ -314,13 +317,15 @@ TEST_CASE( "collision_object multiple broadphase", "[vt]")
 
 struct narrowphase_result
 {
-  narrowphase_result( std::size_t _i )
+  KOKKOS_INLINE_FUNCTION
+  explicit narrowphase_result( std::size_t _i = 0 )
       : idx( _i )
   {}
 
   std::size_t idx;
 };
 
+KOKKOS_INLINE_FUNCTION
 bool operator<( const narrowphase_result &_lhs, const narrowphase_result &_rhs )
 {
   return _lhs.idx < _rhs.idx;
@@ -400,6 +405,8 @@ TEST_CASE( "collision_object narrowphase", "[vt]")
   auto &obj2 = world.create_collision_object();
   bvh::vt::reducable_vector< detailed_narrowphase_result > results;
 
+  Kokkos::View< detailed_narrowphase_result *, Kokkos::DefaultHostExecutionSpace > res;
+
   ::vt::runInEpochCollective( "collision_object.narrowphase", [&]() {
     world.start_iteration();
 
@@ -420,7 +427,7 @@ TEST_CASE( "collision_object narrowphase", "[vt]")
       auto numPossibleCollisions = _a.elements.extent( 0 ) * numNodes * _b.elements.extent( 0 ) * numNodes;
       res.a = bvh::narrowphase_result( sizeof( detailed_narrowphase_result ), numPossibleCollisions );
       res.b = bvh::narrowphase_result( sizeof( detailed_narrowphase_result ), numPossibleCollisions );
-      auto &resa = static_cast< bvh::typed_narrowphase_result< detailed_narrowphase_result > & >( res.a );
+      auto resa = bvh::typed_narrowphase_result< detailed_narrowphase_result >( res.a );
 
       REQUIRE( _a.object.id() == 0 );
       REQUIRE( _b.object.id() == 1 );
@@ -429,26 +436,48 @@ TEST_CASE( "collision_object narrowphase", "[vt]")
       // Second patch number of elements depends on the split algorithm, so not tested
 
       // Global id of the first patch should be the node from whence it came
-      REQUIRE( _a.elements[0].global_id() < static_cast< std::size_t >( ::vt::theContext()->getNumNodes() ) );
+      auto nnodes = static_cast< std::size_t >( ::vt::theContext()->getNumNodes() );
+      Kokkos::View< int > nerrors{ "narrowphase_errors" };
+      Kokkos::parallel_for( 1, KOKKOS_LAMBDA( int ) {
+        if ( _a.elements( 0 ).global_id() >= nnodes )
+          Kokkos::atomic_inc( &nerrors() );
+      } );
 
-      for ( std::size_t i = 0; i < _b.elements.size(); i++ )
-      {
-        REQUIRE( _b.elements( i ).global_id() < static_cast< std::size_t >( ::vt::theContext()->getNumNodes() * 12 ) );
-        resa.emplace_back( detailed_narrowphase_result{ _a.meta.global_id(), _a.elements[0].global_id(),
-                                                        _b.meta.global_id(), _b.elements( i ).global_id() } );
-      }
+      const auto aid = _a.meta.global_id();
+      const auto bid = _b.meta.global_id();
+
+      Kokkos::parallel_for( _b.elements.extent( 0 ), KOKKOS_LAMBDA( int _i ) {
+        auto r = resa;
+        if ( _b.elements( _i ).global_id() >= nnodes * 12 )
+          Kokkos::atomic_inc( &nerrors() );
+        r.emplace_back( detailed_narrowphase_result{ aid, _a.elements( 0 ).global_id(),
+                                                     bid, _b.elements( _i ).global_id() } );
+      } );
+
+      int num_errors_host = 0;
+      Kokkos::deep_copy( num_errors_host, nerrors );
+      REQUIRE( num_errors_host == 0 );
 
       return res;
     } );
 
     obj.broadphase( obj2 );
 
-    results.vec.clear();
-    obj.for_each_result< detailed_narrowphase_result >( [&]( const detailed_narrowphase_result &_res ) {
-      results.vec.emplace_back( _res );
+    obj.with_narrowphase_results< detailed_narrowphase_result >(
+      [&res]( const bvh::typed_narrowphase_result< detailed_narrowphase_result > &_res ) {
+      Kokkos::resize( res,_res.elements().size() );
+      Kokkos::deep_copy( res, _res.elements() );
+      for ( std::size_t i = 0; i < res.size(); ++i )
+      {
+        bvh::vt::debug( "{}: local isect ({}, {}) with ({}, {})\n", ::vt::theContext()->getNode(), res( i ).patch_p, res( i ).element_p,
+                        res( i ).patch_q, res( i ).element_q );
+      }
     } );
 
     world.finish_iteration();
+
+    results.vec.clear();
+    results.vec.insert( results.vec.end(), res.data(), res.data() + res.size() );
   } );
 
   static_assert( std::is_default_constructible_v< detailed_narrowphase_result > );
@@ -592,7 +621,7 @@ TEST_CASE( "collision_object narrowphase three objects", "[vt]" ) {
       auto numPossibleCollisions = _a.elements.extent( 0 ) * numNodes * _b.elements.extent( 0 ) * numNodes;
       res.a = bvh::narrowphase_result( sizeof( detailed_narrowphase_result), numPossibleCollisions );
       res.b = bvh::narrowphase_result( sizeof( detailed_narrowphase_result), numPossibleCollisions );
-      auto &resa = static_cast< bvh::typed_narrowphase_result< detailed_narrowphase_result > & >( res.a );
+      auto resa = bvh::typed_narrowphase_result< detailed_narrowphase_result >( res.a );
 
       Kokkos::parallel_for( _b.elements.extent( 0 ), [=, &resa]( int i ) {
         auto e = _b.elements( i );
@@ -646,9 +675,9 @@ TEST_CASE( "collision_object narrowphase multi-iteration", "[vt]")
   auto &obj = world.create_collision_object();
   auto &obj2 = world.create_collision_object();
 
-  std::vector< narrowphase_result > new_results;
-  std::vector< narrowphase_result > new_results2;
-  std::vector< narrowphase_result > old_results, old_results2;
+  Kokkos::View< narrowphase_result *, Kokkos::HostSpace > new_results;
+  Kokkos::View< narrowphase_result *, Kokkos::HostSpace > new_results2;
+  Kokkos::View< narrowphase_result *, Kokkos::HostSpace > old_results, old_results2;
 
   ::vt::runInEpochCollective( "collision_object.multiple_narrowphase", [&]() {
     for ( std::size_t i = 0; i < 8; ++i ) {
@@ -671,8 +700,8 @@ TEST_CASE( "collision_object narrowphase multi-iteration", "[vt]")
         auto numPossibleCollisions = _b.elements.size() * numNodes;
         res.a = bvh::narrowphase_result( sizeof( narrowphase_result ), numPossibleCollisions );
         res.b = bvh::narrowphase_result( sizeof( narrowphase_result ), numPossibleCollisions );
-        auto &resa = static_cast< bvh::typed_narrowphase_result< narrowphase_result > & >( res.a );
-        auto &resb = static_cast< bvh::typed_narrowphase_result< narrowphase_result > & >( res.b );
+        auto resa = bvh::typed_narrowphase_result< narrowphase_result >( res.a );
+        auto resb = bvh::typed_narrowphase_result< narrowphase_result >( res.b );
 
         REQUIRE( _a.object.id() == 0 );
         REQUIRE( _b.object.id() == 1 );
@@ -681,23 +710,32 @@ TEST_CASE( "collision_object narrowphase multi-iteration", "[vt]")
         // Second patch number of elements depends on the split algorithm, so not tested
 
         // Global id of the first patch should be the node from whence it came
-        REQUIRE( _a.elements[0].global_id() < static_cast< std::size_t >( ::vt::theContext()->getNumNodes() ) );
+        auto nnodes = static_cast< std::size_t >( ::vt::theContext()->getNumNodes() );
+        Kokkos::View< int > nerrors{ "narrowphase_errors" };
+        Kokkos::parallel_for( 1, KOKKOS_LAMBDA( int ) {
+          if ( _a.elements( 0 ).global_id() >= nnodes )
+            Kokkos::atomic_inc( &nerrors() );
+        } );
         bvh::vt::debug("{}: intersect patch ({}, {}) with ({}, {})\n",
                         ::vt::theContext()->getNode(),
                         _a.object.id(), _a.patch_id,
                         _b.object.id(), _b.patch_id );
 
-        for ( std::size_t i = 0; i < _b.elements.size(); i++ )
-        {
-          auto &e = _b.elements( i );
-          CHECK( e.global_id() < static_cast< std::size_t >( ::vt::theContext()->getNumNodes() * 12 ) );
-          bvh::vt::debug("{}: intersect result ({}, {}, {}) with ({}, {}, {})\n",
-                         ::vt::theContext()->getNode(),
-                         _a.object.id(), _a.patch_id, _a.elements[0].global_id(),
-                         _b.object.id(), _b.patch_id, e.global_id() );
-          resa.emplace_back( e.global_id());
-          resb.emplace_back( _a.elements[0].global_id());
-        }
+        const auto aid = _a.meta.global_id();
+        const auto bid = _b.meta.global_id();
+
+        Kokkos::parallel_for( _b.elements.extent( 0 ), KOKKOS_LAMBDA( int _i ) {
+          auto ra = resa;
+          auto rb = resb;
+          if ( _b.elements( _i ).global_id() >= nnodes * 12 )
+            Kokkos::atomic_inc( &nerrors() );
+          ra.emplace_back( _b.elements( _i ).global_id() );
+          rb.emplace_back( _a.elements( 0 ).global_id() );
+        } );
+
+        int num_errors_host = 0;
+        Kokkos::deep_copy( num_errors_host, nerrors );
+        REQUIRE( num_errors_host == 0 );
 
         return res;
       } );
@@ -705,39 +743,40 @@ TEST_CASE( "collision_object narrowphase multi-iteration", "[vt]")
       obj.broadphase( obj2 );
 
       // results for obj
-      new_results.clear();
-      obj.for_each_result< narrowphase_result >( [rank, &new_results]( const narrowphase_result &_res ) {
-        new_results.emplace_back( _res );
-        bvh::vt::debug("{}: got result {}\n", rank, _res.idx );
+      obj.with_narrowphase_results< narrowphase_result >(
+        [&new_results]( const bvh::typed_narrowphase_result< narrowphase_result > &_res ) {
+        Kokkos::resize( new_results,_res.elements().size() );
+        Kokkos::deep_copy( new_results, _res.elements() );
       } );
 
       // results for obj2
-      new_results2.clear();
-      obj2.for_each_result< narrowphase_result >( [&new_results2]( const narrowphase_result &_res ) {
-        new_results2.emplace_back( _res );
+      obj2.with_narrowphase_results< narrowphase_result >(
+        [&new_results2]( const bvh::typed_narrowphase_result< narrowphase_result > &_res ) {
+        Kokkos::resize( new_results2,_res.elements().size() );
+        Kokkos::deep_copy( new_results2, _res.elements() );
       } );
 
       world.finish_iteration();
 
       // Sort results so we get them in a consistent order
-      std::sort( new_results.begin(), new_results.end() );
-      std::sort( new_results2.begin(), new_results2.end() );
+      std::sort( new_results.data(), new_results.data() + new_results.size() );
+      std::sort( new_results2.data(), new_results2.data() + new_results2.size() );
 
       if ( i > 0 ) {
         REQUIRE( old_results.size() == new_results.size());
         for ( std::size_t j = 0; j < old_results.size(); ++j )
-          REQUIRE( old_results.at( j ).idx == new_results.at( j ).idx );
+          REQUIRE( old_results( j ).idx == new_results( j ).idx );
       }
 
-      old_results = new_results;
+      std::swap( old_results, new_results );
 
       if ( i > 0 ) {
         REQUIRE( old_results2.size() == new_results2.size());
         for ( std::size_t j = 0; j < old_results2.size(); ++j )
-          REQUIRE( old_results2.at( j ).idx == new_results2.at( j ).idx );
+          REQUIRE( old_results2( j ).idx == new_results2( j ).idx );
       }
 
-      old_results2 = new_results2;
+      std::swap( old_results2, new_results2 );
     }
   } );
 }
@@ -754,9 +793,11 @@ TEST_CASE( "collision_object narrowphase no overlap multi-iteration", "[vt]")
   auto &obj = world.create_collision_object();
   auto &obj2 = world.create_collision_object();
 
-  ::vt::runInEpochCollective( "collision_object.multiple_narrowphase_no_overlap", [&]() {
-    std::vector< narrowphase_result > old_results, old_results2;
+  Kokkos::View< narrowphase_result *, Kokkos::HostSpace > new_results;
+  Kokkos::View< narrowphase_result *, Kokkos::HostSpace > new_results2;
+  Kokkos::View< narrowphase_result *, Kokkos::HostSpace > old_results, old_results2;
 
+  ::vt::runInEpochCollective( "collision_object.multiple_narrowphase_no_overlap", [&]() {
     for ( std::size_t i = 0; i < 8; ++i ) {
       world.start_iteration();
 
@@ -777,8 +818,8 @@ TEST_CASE( "collision_object narrowphase no overlap multi-iteration", "[vt]")
         auto numPossibleCollisions = _a.elements.extent( 0 ) * numNodes * _b.elements.extent( 0 ) * numNodes;
         res.a = bvh::narrowphase_result( sizeof( narrowphase_result ), numPossibleCollisions );
         res.b = bvh::narrowphase_result( sizeof( narrowphase_result ), numPossibleCollisions );
-        auto &resa = static_cast< bvh::typed_narrowphase_result< narrowphase_result > & >( res.a );
-        auto &resb = static_cast< bvh::typed_narrowphase_result< narrowphase_result > & >( res.b );
+        auto resa = bvh::typed_narrowphase_result< narrowphase_result >( res.a );
+        auto resb = bvh::typed_narrowphase_result< narrowphase_result >( res.b );
 
         REQUIRE( _a.object.id() == 0 );
         REQUIRE( _b.object.id() == 1 );
@@ -802,33 +843,41 @@ TEST_CASE( "collision_object narrowphase no overlap multi-iteration", "[vt]")
 
       obj.broadphase( obj2 );
 
-      std::vector< narrowphase_result > new_results;
-      obj.for_each_result< narrowphase_result >(
-        [&new_results]( const narrowphase_result &_res ) { new_results.emplace_back( _res ); } );
+      // results for obj
+      obj.with_narrowphase_results< narrowphase_result >(
+        [&new_results]( const bvh::typed_narrowphase_result< narrowphase_result > &_res ) {
+        Kokkos::resize( new_results,_res.elements().size() );
+        Kokkos::deep_copy( new_results, _res.elements() );
+      } );
 
-      std::vector< narrowphase_result > new_results2;
-      obj2.for_each_result< narrowphase_result >( [&new_results2]( const narrowphase_result &_res ) {
-        new_results2.emplace_back( _res );
+      // results for obj2
+      obj2.with_narrowphase_results< narrowphase_result >(
+        [&new_results2]( const bvh::typed_narrowphase_result< narrowphase_result > &_res ) {
+        Kokkos::resize( new_results2,_res.elements().size() );
+        Kokkos::deep_copy( new_results2, _res.elements() );
       } );
 
       world.finish_iteration();
 
+      // Sort results so we get them in a consistent order
+      std::sort( new_results.data(), new_results.data() + new_results.size() );
+      std::sort( new_results2.data(), new_results2.data() + new_results2.size() );
+
       if ( i > 0 ) {
         REQUIRE( old_results.size() == new_results.size());
         for ( std::size_t j = 0; j < old_results.size(); ++j )
-          REQUIRE( old_results.at( j ).idx == new_results.at( j ).idx );
+          REQUIRE( old_results( j ).idx == new_results( j ).idx );
       }
 
-      old_results = new_results;
+      std::swap( old_results, new_results );
 
       if ( i > 0 ) {
         REQUIRE( old_results2.size() == new_results2.size());
         for ( std::size_t j = 0; j < old_results2.size(); ++j )
-          REQUIRE( old_results2.at( j ).idx == new_results2.at( j ).idx );
+          REQUIRE( old_results2( j ).idx == new_results2( j ).idx );
       }
 
-      old_results2 = new_results2;
-
+      std::swap( old_results2, new_results2 );
     }
   } );
 }


### PR DESCRIPTION
Fixes #11

Current test output with CUDA (using the latest `nmm0/distbvh-cuda11.4.3-gcc9.4-x64:ci-images` image):
```
root@38a49e42f9cb:/distBVH# ctest --preset ci-cuda11_4-x64-Debug             
Test project /opt/builds/bvh/debug
      Start  1: kdop - bvh::dop_6d
 1/76 Test  #1: kdop - bvh::dop_6d ...........................................................   Passed    0.12 sec
      Start  2: kdop - bvh::dop_26d
 2/76 Test  #2: kdop - bvh::dop_26d ..........................................................   Passed    0.12 sec
      Start  3: a tree constructed from an empty range has a depth of 0
 3/76 Test  #3: a tree constructed from an empty range has a depth of 0 ......................   Passed    0.12 sec
      Start  4: a tree constructed from N elements exists and has that many nodes
 4/76 Test  #4: a tree constructed from N elements exists and has that many nodes ............   Passed    0.19 sec
      Start  5: a tree constructed from overlapping elements correctly splits the elements
 5/76 Test  #5: a tree constructed from overlapping elements correctly splits the elements ...   Passed    0.12 sec
      Start  6: a preorder traversal of a full tree yields N * 2 - 1 nodes in total
 6/76 Test  #6: a preorder traversal of a full tree yields N * 2 - 1 nodes in total ..........   Passed    0.12 sec
      Start  7: a leaf traversal of a full tree yields N nodes
 7/76 Test  #7: a leaf traversal of a full tree yields N nodes ...............................   Passed    0.12 sec
      Start  8: a tree copy is identical
 8/76 Test  #8: a tree copy is identical .....................................................   Passed    0.13 sec
      Start  9: a tree copy of a single node tree is identical
 9/76 Test  #9: a tree copy of a single node tree is identical ...............................   Passed    0.13 sec
      Start 10: a tree copy of an empty tree is identical and empty
10/76 Test #10: a tree copy of an empty tree is identical and empty ..........................   Passed    0.12 sec
      Start 11: a moved tree is valid and containts the original number of elements
11/76 Test #11: a moved tree is valid and containts the original number of elements ..........   Passed    0.12 sec
      Start 12: a moved tree with one element is valid and contains only one element
12/76 Test #12: a moved tree with one element is valid and contains only one element .........   Passed    0.12 sec
      Start 13: a moved empty tree is valid and empty
13/76 Test #13: a moved empty tree is valid and empty ........................................   Passed    0.11 sec
      Start 14: empty patches in tree build
14/76 Test #14: empty patches in tree build ..................................................   Passed    0.12 sec
      Start 15: bottom up build
15/76 Test #15: bottom up build ..............................................................   Passed    0.12 sec
      Start 16: bottom up single build
16/76 Test #16: bottom up single build .......................................................   Passed    0.12 sec
      Start 17: bottom up multi build
17/76 Test #17: bottom up multi build ........................................................   Passed    0.15 sec
      Start 18: two fully overlapping element groups all collide
18/76 Test #18: two fully overlapping element groups all collide .............................   Passed    0.12 sec
      Start 19: a non-overlapping element group does not self-collide
19/76 Test #19: a non-overlapping element group does not self-collide ........................   Passed    0.11 sec
      Start 20: an overlapping element group self-collides
20/76 Test #20: an overlapping element group self-collides ...................................   Passed    0.12 sec
      Start 21: the zip iterator can be constructed from two ranges of differing type
21/76 Test #21: the zip iterator can be constructed from two ranges of differing type ........   Passed    0.12 sec
      Start 22: level iterators iterate through each level of a tree
22/76 Test #22: level iterators iterate through each level of a tree .........................   Passed    0.11 sec
      Start 23: a single value can be serialized - int
23/76 Test #23: a single value can be serialized - int .......................................   Passed    0.12 sec
      Start 24: a single value can be serialized - double
24/76 Test #24: a single value can be serialized - double ....................................   Passed    0.11 sec
      Start 25: a single value can be serialized - float
25/76 Test #25: a single value can be serialized - float .....................................   Passed    0.11 sec
      Start 26: a single value can be serialized - std::size_t
26/76 Test #26: a single value can be serialized - std::size_t ...............................   Passed    0.12 sec
      Start 27: vector serialization - float
27/76 Test #27: vector serialization - float .................................................   Passed    0.13 sec
      Start 28: vector serialization - double
28/76 Test #28: vector serialization - double ................................................   Passed    0.12 sec
      Start 29: kdop serialization
29/76 Test #29: kdop serialization ...........................................................   Passed    0.11 sec
      Start 30: patch serialization
30/76 Test #30: patch serialization ..........................................................   Passed    0.11 sec
      Start 31: ghost_msg serialization
31/76 Test #31: ghost_msg serialization ......................................................   Passed    0.12 sec
      Start 32: narrowphase_patches collection serialization
32/76 Test #32: narrowphase_patches collection serialization .................................   Passed    0.16 sec
      Start 33: clz 32bit
33/76 Test #33: clz 32bit ....................................................................   Passed    0.12 sec
      Start 34: clz 64bit
34/76 Test #34: clz 64bit ....................................................................   Passed    0.12 sec
      Start 35: morton hashing
35/76 Test #35: morton hashing ...............................................................   Passed    0.13 sec
      Start 36: quantization
36/76 Test #36: quantization .................................................................   Passed    0.12 sec
      Start 37: radix sort
37/76 Test #37: radix sort ...................................................................   Passed    0.13 sec
      Start 38: in place recursive mean splitting
38/76 Test #38: in place recursive mean splitting ............................................   Passed    0.12 sec
      Start 39: recursive mean splitting 1D elements
39/76 Test #39: recursive mean splitting 1D elements .........................................   Passed    0.12 sec
      Start 40: recursive mean splitting 2D elements
40/76 Test #40: recursive mean splitting 2D elements .........................................   Passed    0.12 sec
      Start 41: kokkos prefix sum yields the correct results
41/76 Test #41: kokkos prefix sum yields the correct results .................................   Passed    0.12 sec
      Start 42: vec init
42/76 Test #42: vec init .....................................................................   Passed    0.12 sec
      Start 43: vec add
43/76 Test #43: vec add ......................................................................   Passed    0.12 sec
      Start 44: vec sub
44/76 Test #44: vec sub ......................................................................   Passed    0.14 sec
      Start 45: vec mul
45/76 Test #45: vec mul ......................................................................   Passed    0.11 sec
      Start 46: vec div
46/76 Test #46: vec div ......................................................................   Passed    0.11 sec
      Start 47: vec scalar mul
47/76 Test #47: vec scalar mul ...............................................................   Passed    0.12 sec
      Start 48: vec scalar div
48/76 Test #48: vec scalar div ...............................................................   Passed    0.12 sec
      Start 49: vec hadd
49/76 Test #49: vec hadd .....................................................................   Passed    0.14 sec
      Start 50: vec dot
50/76 Test #50: vec dot ......................................................................   Passed    0.12 sec
      Start 51: vec length2
51/76 Test #51: vec length2 ..................................................................   Passed    0.12 sec
      Start 52: vec length
52/76 Test #52: vec length ...................................................................   Passed    0.12 sec
      Start 53: vec sqrt
53/76 Test #53: vec sqrt .....................................................................   Passed    0.13 sec
      Start 54: vec normal
54/76 Test #54: vec normal ...................................................................   Passed    0.13 sec
      Start 55: vec ceil
55/76 Test #55: vec ceil .....................................................................   Passed    0.13 sec
      Start 56: vec floor
56/76 Test #56: vec floor ....................................................................   Passed    0.15 sec
      Start 57: vec access
57/76 Test #57: vec access ...................................................................   Passed    0.14 sec
      Start 58: vec const convert
58/76 Test #58: vec const convert ............................................................   Passed    0.12 sec
      Start 59: collision_object init
59/76 Test #59: collision_object init ........................................................   Passed    0.12 sec
      Start 60: collision_object broadphase
60/76 Test #60: collision_object broadphase ..................................................   Passed    0.13 sec
      Start 61: collision_object multiple broadphase
61/76 Test #61: collision_object multiple broadphase .........................................   Passed    0.13 sec
      Start 62: collision_object narrowphase
62/76 Test #62: collision_object narrowphase .................................................   Passed    0.12 sec
      Start 63: collision_object narrowphase multi-iteration
63/76 Test #63: collision_object narrowphase multi-iteration .................................   Passed    0.17 sec
      Start 64: collision_object narrowphase no overlap multi-iteration
64/76 Test #64: collision_object narrowphase no overlap multi-iteration ......................   Passed    0.16 sec
      Start 65: spatial clustering
65/76 Test #65: spatial clustering ...........................................................   Passed    0.13 sec
      Start 66: snapshot
66/76 Test #66: snapshot .....................................................................   Passed    0.13 sec
      Start 67: mpi_collision_object_multiple_broadphase_np_2
67/76 Test #67: mpi_collision_object_multiple_broadphase_np_2 ................................   Passed    0.42 sec
      Start 68: mpi_collision_object_multiple_broadphase_np_4
68/76 Test #68: mpi_collision_object_multiple_broadphase_np_4 ................................   Passed    0.80 sec
      Start 69: mpi_collision_object_narrowphase_np_2
69/76 Test #69: mpi_collision_object_narrowphase_np_2 ........................................   Passed    0.59 sec
      Start 70: mpi_collision_object_narrowphase_np_4
70/76 Test #70: mpi_collision_object_narrowphase_np_4 ........................................   Passed    1.81 sec
      Start 71: mpi_collision_object_narrowphase_three_objects_np_2
71/76 Test #71: mpi_collision_object_narrowphase_three_objects_np_2 ..........................   Passed    0.22 sec
      Start 72: mpi_collision_object_narrowphase_three_objects_np_4
72/76 Test #72: mpi_collision_object_narrowphase_three_objects_np_4 ..........................   Passed    0.40 sec
      Start 73: mpi_collision_object_narrowphase_multi_iteration_np_2
73/76 Test #73: mpi_collision_object_narrowphase_multi_iteration_np_2 ........................   Passed    1.74 sec
      Start 74: mpi_collision_object_narrowphase_multi_iteration_np_4
74/76 Test #74: mpi_collision_object_narrowphase_multi_iteration_np_4 ........................   Passed    8.75 sec
      Start 75: mpi_collision_object_narrowphase_no_overlap_multi_iteration_np_2
75/76 Test #75: mpi_collision_object_narrowphase_no_overlap_multi_iteration_np_2 .............   Passed    0.56 sec
      Start 76: mpi_collision_object_narrowphase_no_overlap_multi_iteration_np_4
76/76 Test #76: mpi_collision_object_narrowphase_no_overlap_multi_iteration_np_4 .............   Passed    1.45 sec

100% tests passed, 0 tests failed out of 76

Total Test time (real) =  25.03 sec
```