### PR TITLE
#34: fix compilation warnings

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -13,6 +13,7 @@
       "cacheVariables": {
         "CMAKE_C_COMPILER": "gcc-11",
         "CMAKE_CXX_COMPILER": "g++-11",
+        "CMAKE_CXX_FLAGS": "-Wall -Wextra",
         "CMAKE_PREFIX_PATH": "/opt/view",
         "CMAKE_BUILD_TYPE": "Release",
         "BVH_DISABLE_TESTS": "OFF"

--- a/src/bvh/bvh_build.hpp
+++ b/src/bvh/bvh_build.hpp
@@ -158,16 +158,16 @@ namespace bvh
       {
         m_global_bounds = KDop( make_transform_iterator( _elements.begin(), element_traits< T >::get_kdop ),
                         make_transform_iterator( _elements.end(), element_traits< T >::get_kdop ) );
-        
+
         // A single element will cause divide-by-zeros if we don't do this
         m_global_bounds.inflate( m::epsilon );
       }
-  
+
       template< typename Vec >
       m::vec3< std::uint64_t > discretize_coord( Vec &&_coord )
       {
         m::vec3< std::uint64_t > ret;
-    
+
         for ( int i = 0; i < 3; ++i )
         {
           auto inv_fac = typename KDop::arithmetic_type{ 1 } / m_global_bounds.extents[i].length();
@@ -256,10 +256,8 @@ namespace bvh
        *
        *  \tparam InputIterator   The iterator type for collision entities.
        */
-      void build( std::size_t _node_index,
-                  T *_entities,
-                  std::size_t _entity_begin, std::size_t _entity_end,
-                  std::size_t _entities_per_leaf )
+      void build( [[maybe_unused]] std::size_t _node_index, T *_entities, std::size_t _entity_begin,
+                  std::size_t _entity_end, [[maybe_unused]] std::size_t _entities_per_leaf )
       {
 
         dynarray< treelet_type > treelets;

--- a/src/bvh/collision_object.cpp
+++ b/src/bvh/collision_object.cpp
@@ -31,21 +31,13 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "collision_object.hpp"
-#include "kdop.hpp"
-#include "tree.hpp"
-#include "util/bits.hpp"
-#include "split/split.hpp"
-#include "split/mean.hpp"
-#include "split/axis.hpp"
 #include "debug/assert.hpp"
 #include "collision_object/types.hpp"
 #include "collision_object/impl.hpp"
 #include "collision_object/top_down.hpp"
 #include "collision_object/broadphase.hpp"
 #include "collision_object/narrowphase.hpp"
-#include <cstddef>
 #include <unordered_map>
-#include <typeinfo>
 
 namespace bvh
 {

--- a/src/bvh/collision_object.cpp
+++ b/src/bvh/collision_object.cpp
@@ -43,6 +43,7 @@
 #include "collision_object/top_down.hpp"
 #include "collision_object/broadphase.hpp"
 #include "collision_object/narrowphase.hpp"
+#include <cstddef>
 #include <unordered_map>
 #include <typeinfo>
 
@@ -90,7 +91,7 @@ namespace bvh
 
     m_impl->overdecomposition = static_cast< int >( _overdecomposition );
 
-    for ( std::size_t i = 0; i < m_impl->overdecomposition; ++i )
+    for ( std::size_t i = 0; i < _overdecomposition; ++i )
     {
       m_impl->chainset.addIndex( vt_index{ i } );
     }
@@ -115,7 +116,7 @@ namespace bvh
   void collision_object::set_entity_data_impl( const void *_data, std::size_t _element_size )
   {
     const int rank = static_cast< int >( ::vt::theContext()->getNode() );
-    const auto od_factor = m_impl->overdecomposition;
+    const auto od_factor = static_cast< std::size_t >( m_impl->overdecomposition );
 
     m_impl->num_splits = m_impl->splits.extent( 0 );
 
@@ -124,8 +125,7 @@ namespace bvh
     m_impl->local_patches.clear();
     m_impl->local_patches.resize( od_factor );
 
-    BVH_ASSERT_ALWAYS( m_impl->num_splits + 1 == od_factor,
-                       logger(),
+    BVH_ASSERT_ALWAYS( m_impl->num_splits + 1 == static_cast< std::size_t >( od_factor ), logger(),
                        "error during splitting process, splits {} do not match od factor {}\n", m_impl->num_splits + 1,
                        od_factor );
 
@@ -310,7 +310,7 @@ namespace bvh
   collision_object::set_all_narrow_patches(){
 
     const int rank = static_cast< int >( ::vt::theContext()->getNode() );
-    const auto od_factor = m_impl->overdecomposition;
+    const auto od_factor = static_cast< std::size_t >( m_impl->overdecomposition );
 
     for ( std::size_t i = 0; i < od_factor; ++i )
       m_impl->narrowphase_patch_messages[i] = m_impl->prepare_local_patch_for_sending( i, rank );
@@ -333,8 +333,6 @@ namespace bvh
   void
   collision_object::set_active_narrow_patches(){
     int rank = static_cast< int >( ::vt::theContext()->getNode() );
-    const auto od_factor = m_impl->overdecomposition;
-    const std::size_t offset = rank * od_factor;
 
     m_impl->chainset.nextStepCollective( "set_narrowphase_patches", [this, rank]( vt_index _idx ) {
       if ( _idx.x() == 0 ) {

--- a/src/bvh/collision_object.cpp
+++ b/src/bvh/collision_object.cpp
@@ -81,9 +81,9 @@ namespace bvh
     bvh_build_trees_ = ::vt::theTrace()->registerUserEventColl( "bvh_build_trees_" );
     m_impl->logger->trace( "obj={} registered user tracing event bvh_build_trees_", m_impl->collision_idx );
 
-    m_impl->overdecomposition = static_cast< int >( _overdecomposition );
+    m_impl->overdecomposition = _overdecomposition;
 
-    for ( std::size_t i = 0; i < _overdecomposition; ++i )
+    for ( std::size_t i = 0; i < m_impl->overdecomposition; ++i )
     {
       m_impl->chainset.addIndex( vt_index{ i } );
     }
@@ -108,7 +108,7 @@ namespace bvh
   void collision_object::set_entity_data_impl( const void *_data, std::size_t _element_size )
   {
     const int rank = static_cast< int >( ::vt::theContext()->getNode() );
-    const auto od_factor = static_cast< std::size_t >( m_impl->overdecomposition );
+    const auto od_factor = m_impl->overdecomposition;
 
     m_impl->num_splits = m_impl->splits.extent( 0 );
 
@@ -117,7 +117,7 @@ namespace bvh
     m_impl->local_patches.clear();
     m_impl->local_patches.resize( od_factor );
 
-    BVH_ASSERT_ALWAYS( m_impl->num_splits + 1 == static_cast< std::size_t >( od_factor ), logger(),
+    BVH_ASSERT_ALWAYS( m_impl->num_splits + 1 == od_factor, logger(),
                        "error during splitting process, splits {} do not match od factor {}\n", m_impl->num_splits + 1,
                        od_factor );
 
@@ -302,7 +302,7 @@ namespace bvh
   collision_object::set_all_narrow_patches(){
 
     const int rank = static_cast< int >( ::vt::theContext()->getNode() );
-    const auto od_factor = static_cast< std::size_t >( m_impl->overdecomposition );
+    const auto od_factor = m_impl->overdecomposition;
 
     for ( std::size_t i = 0; i < od_factor; ++i )
       m_impl->narrowphase_patch_messages[i] = m_impl->prepare_local_patch_for_sending( i, rank );

--- a/src/bvh/collision_object.hpp
+++ b/src/bvh/collision_object.hpp
@@ -36,7 +36,6 @@
 #include <cstddef>
 #include <memory>
 #include <functional>
-#include <optional>
 #include <vt/context/context.h>
 #include <spdlog/spdlog.h>
 
@@ -48,7 +47,6 @@
 #include "types.hpp"
 #include "util/span.hpp"
 #include "split/cluster.hpp"
-#include "contact_entity.hpp"
 
 namespace bvh
 {

--- a/src/bvh/collision_object/impl.cpp
+++ b/src/bvh/collision_object/impl.cpp
@@ -62,7 +62,7 @@ namespace bvh
       self->get_impl().active_narrowphase_local_index.insert( _msg->idx.x() );
     }
 
-    void collision_object_holder::setup_narrowphase( setup_narrowphase_msg *_msg )
+    void collision_object_holder::setup_narrowphase( [[maybe_unused]] setup_narrowphase_msg *_msg )
     {
       auto &logger = self->broadphase_logger();
       auto &impl = self->get_impl();
@@ -82,7 +82,7 @@ namespace bvh
       }
     }
 
-    void collision_object_holder::activate_narrowphase( start_activate_narrowphase_msg *_msg )
+    void collision_object_holder::activate_narrowphase( [[maybe_unused]] start_activate_narrowphase_msg *_msg )
     {
       auto &logger = self->narrowphase_logger();
       auto &impl = self->get_impl();
@@ -114,7 +114,7 @@ namespace bvh
       }
     }
 
-    void collision_object_holder::start_narrowphase( start_narrowphase_msg *_msg )
+    void collision_object_holder::start_narrowphase( [[maybe_unused]] start_narrowphase_msg *_msg )
     {
       auto &impl = self->get_impl();
       for ( auto &&idx : impl.active_narrowphase_indices )
@@ -125,7 +125,7 @@ namespace bvh
       }
     }
 
-    void collision_object_holder::clear_narrowphase( clear_narrowphase_msg *_msg )
+    void collision_object_holder::clear_narrowphase( [[maybe_unused]] clear_narrowphase_msg *_msg )
     {
       auto &impl = self->get_impl();
       for ( auto &&idx : impl.active_narrowphase_indices )

--- a/src/bvh/collision_object/impl.hpp
+++ b/src/bvh/collision_object/impl.hpp
@@ -139,7 +139,7 @@ namespace bvh
     std::vector< narrowphase_result > local_results;
 
     ::vt::messaging::CollectionChainSet< vt_index > chainset;
-    int overdecomposition = 1;
+    std::size_t overdecomposition = 1;
     bool build_trees = true;
 
     // 1D collection of patch metadata, each index in the collection corresponds to the same index in narrowphase_patch_collection_proxy

--- a/src/bvh/collision_object/narrowphase.cpp
+++ b/src/bvh/collision_object/narrowphase.cpp
@@ -41,19 +41,19 @@ namespace bvh
 {
   namespace collision_object_impl
   {
-    pending_send activate_narrowphase( vt_index _local_idx, collision_object_proxy_type _this_obj )
+    pending_send activate_narrowphase( [[maybe_unused]] vt_index _local_idx, collision_object_proxy_type _this_obj )
     {
       auto msg = ::vt::makeMessage< start_activate_narrowphase_msg >();
       return _this_obj[::vt::theContext()->getNode()].sendMsg< start_activate_narrowphase_msg, &collision_object_impl::collision_object_holder::activate_narrowphase >( msg );
     }
 
-    pending_send clear_narrowphase( vt_index _local_idx, collision_object_proxy_type _this_obj )
+    pending_send clear_narrowphase( [[maybe_unused]] vt_index _local_idx, collision_object_proxy_type _this_obj )
     {
       auto msg = ::vt::makeMessage< clear_narrowphase_msg >();
       return _this_obj[::vt::theContext()->getNode()].sendMsg< clear_narrowphase_msg, &collision_object_impl::collision_object_holder::clear_narrowphase >( msg );
     }
 
-    pending_send narrowphase( vt_index _local_idx, collision_object_proxy_type _this_obj )
+    pending_send narrowphase( [[maybe_unused]] vt_index _local_idx, collision_object_proxy_type _this_obj )
     {
       auto msg = ::vt::makeMessage< start_narrowphase_msg >();
       return _this_obj[::vt::theContext()->getNode()].sendMsg< start_narrowphase_msg, &collision_object_impl::collision_object_holder::start_narrowphase >( msg );
@@ -87,8 +87,7 @@ namespace bvh
       return _patches[_global_idx].sendMsg< narrowphase_patch_msg, &details::copy_narrowphase_patch >( this_msg );
     }
 
-    pending_send request_ghosts( vt_index _local_idx,
-                                 collision_object_proxy_type _this_obj,
+    pending_send request_ghosts( [[maybe_unused]] vt_index _local_idx, collision_object_proxy_type _this_obj,
                                  collision_object_proxy_type _other_obj )
     {
       auto &this_obj = _this_obj.get()->self;

--- a/src/bvh/debug/assert.hpp
+++ b/src/bvh/debug/assert.hpp
@@ -53,7 +53,7 @@ namespace bvh
     struct debug_assert_impl
     {
       template< typename... Args >
-      static void debug_assert( bool, const std::string &, Args &&... _args )
+      static void debug_assert( bool, const std::string &, [[maybe_unused]] Args &&..._args )
       {
         // Do nothing
       }

--- a/src/bvh/debug/assert.hpp
+++ b/src/bvh/debug/assert.hpp
@@ -35,7 +35,6 @@
 
 #include <cstdlib>
 #include <string>
-#include <iostream>
 #include "../vt/print.hpp"
 #include <spdlog/spdlog.h>
 

--- a/src/bvh/math/ops/constexpr_arithmetic.hpp
+++ b/src/bvh/math/ops/constexpr_arithmetic.hpp
@@ -74,8 +74,8 @@ namespace bvh
         }
 
         template< typename T, typename U, unsigned N >
-        constexpr BVH_INLINE auto
-        add( const constant_vec< T, N > &_lhs, const constant_vec< U, N > &_rhs )
+        constexpr BVH_INLINE auto add( [[maybe_unused]] const constant_vec< T, N > &_lhs,
+                                       [[maybe_unused]] const constant_vec< U, N > &_rhs )
         {
           using result_type = decltype( T{} + U{} );
           constant_vec< result_type, N > ret;

--- a/src/bvh/split/cluster.hpp
+++ b/src/bvh/split/cluster.hpp
@@ -158,12 +158,12 @@ namespace bvh
 
     // We want the first cluster_count indices -- but they have to be in sorted index order
     // Mark these with 1, then we can execute an exclusive scan to re-index
-    Kokkos::parallel_for( n - 1, [this, cluster_count] KOKKOS_FUNCTION( int _i ) {
+    Kokkos::parallel_for( n - 1, [this, cluster_count] KOKKOS_FUNCTION( std::size_t _i ) {
       m_reindex( m_depths_indices( _i ) ) = ( _i < cluster_count ) ? 1 : 0;
     } );
 
     prefix_sum( m_reindex );
-    Kokkos::parallel_for( n - 1, [this, _splits, cluster_count] KOKKOS_FUNCTION( int _i ) {
+    Kokkos::parallel_for( n - 1, [this, _splits, cluster_count] KOKKOS_FUNCTION( std::size_t _i ) {
       if ( _i < cluster_count )
       {
         auto new_idx = m_reindex( m_depths_indices( _i ) );

--- a/src/bvh/split/cluster.hpp
+++ b/src/bvh/split/cluster.hpp
@@ -1,13 +1,9 @@
 #ifndef INC_BVH_CLUSTER_HPP
 #define INC_BVH_CLUSTER_HPP
 
-#include "../util/span.hpp"
-#include "../vt/print.hpp"
 #include "../util/kokkos.hpp"
 #include "../util/sort.hpp"
-#include "../snapshot.hpp"
 #include "../contact_entity.hpp"
-#include "split.hpp"
 
 namespace bvh
 {

--- a/src/bvh/tree_build.hpp
+++ b/src/bvh/tree_build.hpp
@@ -56,15 +56,15 @@ namespace bvh
   {
     auto &leafs = _tree.m_leafs;
     auto &nodes = _tree.m_nodes;
-    
+
     leafs.clear();
     nodes.clear();
-    
+
     if ( !_elements.empty() )
     {
       // Store indices to collision objects
       leafs.assign( _elements.begin(), _elements.end() );
-    
+
       auto b = typename TreeBuildPolicy::template builder< T, KDop, NodeData >( span< const T >( leafs.data(), leafs.size() ), nodes );
       b.build( 0, leafs.data(), 0, leafs.size(), 1 );
     }
@@ -84,7 +84,7 @@ namespace bvh
   {
     Tree ret;
     rebuild_tree< TreeBuildPolicy >( ret, _elements );
-    
+
     return ret;
   }
 

--- a/src/bvh/util/bits.hpp
+++ b/src/bvh/util/bits.hpp
@@ -59,7 +59,7 @@ namespace bvh
   T fill()
   {
 #ifdef __GNUC__
-    T t = t;
+    T t;
     __builtin_memset( &t, V, sizeof( T ) );
 #else
 #error "unsupported compiler for find first set"

--- a/src/bvh/util/span.hpp
+++ b/src/bvh/util/span.hpp
@@ -103,8 +103,7 @@ namespace bvh
     constexpr span( pointer _ptr, index_type _count )
       : m_data( _ptr ), m_count( _count )
     {
-      BVH_ASSERT( extent == dynamic_extent() || _count == extent );
-
+      BVH_ASSERT( extent == dynamic_extent() || _count == static_cast< index_type >( extent ) );
     }
 
     constexpr span( pointer _first, pointer _last )
@@ -175,7 +174,7 @@ namespace bvh
 
     constexpr reference operator[]( index_type _idx ) const
     {
-      BVH_ASSERT( ( _idx >= 0 ) && ( _idx < m_count ) );
+      BVH_ASSERT( _idx < m_count );
       return m_data[_idx];
     }
 

--- a/src/bvh/util/span.hpp
+++ b/src/bvh/util/span.hpp
@@ -80,7 +80,7 @@ namespace bvh
 
     using element_type = T;
     using value_type = std::remove_reference_t< std::remove_const_t< T > >;
-    using index_type = std::ptrdiff_t;
+    using index_type = std::size_t;
     using difference_type = std::ptrdiff_t;
     using pointer = T *;
     using reference = T &;

--- a/tests/SerializerTest.cpp
+++ b/tests/SerializerTest.cpp
@@ -164,7 +164,7 @@ namespace
     _coll->migrate( dest );
   }
 
-  void narrowphase_patch_check( bvh::collision_object_impl::narrowphase_patch_collection_type *_coll )
+  [[maybe_unused]] void narrowphase_patch_check( bvh::collision_object_impl::narrowphase_patch_collection_type *_coll )
   {
     auto k = bvh::bphase_kdop::from_sphere( bvh::m::vec3d{ 17.53, 21.9, 36.0 }, 2.7 );
     bvh::patch<> p( 13, 4096, k, bvh::m::vec3d{ 17.3, 20.6, 33.31 } );
@@ -192,23 +192,21 @@ TEST_CASE("narrowphase_patches collection serialization", "[serializer][collisio
     auto ep = ::vt::theTerm()->makeEpochCollective( "narrowphase_patch_test" );
     ::vt::theMsg()->pushEpoch( ep );
 
-
-    auto collection = ::vt::theCollection()
-        ->constructCollective< narrowphase_patch_collection_type >( coll_size,
-            []( vt_index _idx ) {
-              auto ret = std::make_unique< narrowphase_patch_collection_type >();
-              auto k = bvh::bphase_kdop::from_sphere( bvh::m::vec3d{ 17.53, 21.9, 36.0 }, 2.7 );
-              bvh::patch<> p( 13, 4096, k, bvh::m::vec3d{ 17.3, 20.6, 33.31 } );
-              ret->patch_meta = p;
-              ret->origin_node = 17;
-              std::vector< double > vals;
-              vals.reserve( 4096 );
-              for ( std::size_t i = 0; i < 4096; ++i )
-                vals.push_back( static_cast< double >( i + 1 ) );
-              ret->bytes.resize( 4096 * sizeof( double ) );
-              std::memcpy( ret->bytes.data(), vals.data(), ret->bytes.size() );
-              return ret;
-            } );
+    auto collection = ::vt::theCollection()->constructCollective< narrowphase_patch_collection_type >(
+      coll_size, []( [[maybe_unused]] vt_index _idx ) {
+      auto ret = std::make_unique< narrowphase_patch_collection_type >();
+      auto k = bvh::bphase_kdop::from_sphere( bvh::m::vec3d{ 17.53, 21.9, 36.0 }, 2.7 );
+      bvh::patch<> p( 13, 4096, k, bvh::m::vec3d{ 17.3, 20.6, 33.31 } );
+      ret->patch_meta = p;
+      ret->origin_node = 17;
+      std::vector< double > vals;
+      vals.reserve( 4096 );
+      for ( std::size_t i = 0; i < 4096; ++i )
+        vals.push_back( static_cast< double >( i + 1 ) );
+      ret->bytes.resize( 4096 * sizeof( double ) );
+      std::memcpy( ret->bytes.data(), vals.data(), ret->bytes.size() );
+      return ret;
+    } );
 
     for ( std::size_t i = 0; i < 1000; ++i )
     {

--- a/tests/SplitTest.cpp
+++ b/tests/SplitTest.cpp
@@ -77,7 +77,7 @@ namespace
 
     const kdop_type &kdop() const noexcept{ return m_kdop; }
     const bvh::m::vec3d &centroid() const noexcept { return m_centroid; }
-    const unsigned global_id() const noexcept { return m_gid; }
+    unsigned global_id() const noexcept { return m_gid; }
   };
 }
 
@@ -333,8 +333,6 @@ TEST_CASE("recursive mean splitting 2D elements", "[split]")
 
 TEST_CASE("new recursive mean splitting 2D elements", "[split]")
 {
-  using traits_type = bvh::element_traits< element< bvh::bphase_kdop > >;
-
   static constexpr std::size_t Nx = 4, Ny = 3;
   static constexpr std::size_t N = Nx * Ny;
   std::array< bvh::entity_snapshot, N > elements;
@@ -438,6 +436,4 @@ TEST_CASE("new recursive mean splitting 2D elements", "[split]")
     }
     //
   }
-
 }
-

--- a/tests/TestCommon.hpp
+++ b/tests/TestCommon.hpp
@@ -192,8 +192,6 @@ build_element_grid( int _x, int _y, int _z, std::size_t _base_index = 0, double 
   double dy = 1.0 / _y;
   double dz = 1.0 / _z;
 
-  std::size_t index = _base_index;
-
   auto rp = Kokkos::MDRangePolicy<Kokkos::Rank<3>>{{ 0, 0, 0 }, { _x, _y, _z }};
   Kokkos::parallel_for(rp, KOKKOS_LAMBDA( int _i, int _j, int _k ) {
     double x = _origin_shift + _i * dx;

--- a/tests/TestMain.cpp
+++ b/tests/TestMain.cpp
@@ -61,9 +61,7 @@ main( int _argc, char **_argv )
     if ( argret != 0 )
       return argret;
 
-    vt::runInEpochCollective( "main test", [_argc, _argv, &ret, &sesh](){
-      ret = sesh.run();
-    } );
+    vt::runInEpochCollective( "main test", [&ret, &sesh]() { ret = sesh.run(); } );
 
     ::vt::finalize();
   }

--- a/tests/bits_test.cpp
+++ b/tests/bits_test.cpp
@@ -39,7 +39,8 @@
 TEST_CASE("clz 32bit", "[clz]")
 {
   REQUIRE( 32 == bvh::clz(std::uint32_t {0}) );
-  for (int i = 0; i < 32; i++) {
+  for ( std::uint32_t i = 0; i < 32; i++ )
+  {
     std::uint32_t val = 1u << i;
     REQUIRE( 31 - i == bvh::clz(val) );
   }
@@ -48,7 +49,8 @@ TEST_CASE("clz 32bit", "[clz]")
 TEST_CASE("clz 64bit", "[clz]")
 {
   REQUIRE( 64 == bvh::clz(std::uint64_t {0}) );
-  for (int i = 0; i < 64; i++) {
+  for ( std::uint32_t i = 0; i < 64; i++ )
+  {
     std::uint64_t val = 1ull << i;
     REQUIRE( 63 - i == bvh::clz(val) );
   }

--- a/tests/hash_test.cpp
+++ b/tests/hash_test.cpp
@@ -201,7 +201,7 @@ TEST_CASE("benchmark morton", "[hash][!benchmark]")
 
   BENCHMARK("morton64")
   {
-    volatile std::uint64_t ret;
+    [[maybe_unused]] volatile std::uint64_t ret;
 
     for ( int i = 0; i < 3000; i += 3 )
     {
@@ -212,7 +212,7 @@ TEST_CASE("benchmark morton", "[hash][!benchmark]")
 #ifdef __BMI2__
   BENCHMARK("morton64 intrin")
   {
-    volatile std::uint64_t ret;
+    [[maybe_unused]] volatile std::uint64_t ret;
 
     for ( int i = 0; i < 3000; i += 3 )
     {


### PR DESCRIPTION
fixes #34 

Most of the warnings are unused parameter, mixed sign comparison or unused variable.
For the unused parameters, I went with `[[maybe_unused]]` to be more explicit. Maybe it makes sense to remove some of them completely instead.