### PR TITLE
#40: [CI] fix Node.js deprecation warnings

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Log in to Docker Hub
         if: ${{ github.ref == 'refs/heads/ci-images' }}
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -37,10 +37,10 @@ jobs:
       - name: Pull Cached Image
         run: docker pull ${{ env.IMAGE_TAG }}
         continue-on-error: true
-      
+
       - name: Build Docker images for PR testing
         if: ${{ github.event_name == 'pull_request' }}
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ${{ matrix.image }}.dockerfile


### PR DESCRIPTION
fixes #40 

@nmm0 This will also trigger rebuilding docker images, which is necessary for pulling in the latest `magistrate` version.