### PR TITLE
#43: Add multibody contact test

### DIFF
--- a/src/bvh/collision_object/impl.cpp
+++ b/src/bvh/collision_object/impl.cpp
@@ -276,7 +276,7 @@ namespace bvh
       auto &other_impl = other_obj.get_impl();
 
       auto &logger = this_obj.narrowphase_logger();
-      logger.debug( "executing narrowphase <{}, {}, {}, {}> in epoch={}", this_obj.id(), idx[0], idx[1],
+      logger.debug( "executing narrowphase <obj {}, patch {} | obj {}, patch {}> in epoch={}", this_obj.id(), idx[0], idx[1],
                     idx[2], ::vt::theMsg()->getEpoch() );
 
       // Run actual narrowphase functor
@@ -289,7 +289,7 @@ namespace bvh
       // Only run if we are looking at the right "other obj"
       if ( other_obj.get_impl().collision_idx != static_cast< std::size_t >( idx.y() ) )
       {
-        logger.trace( "skipping <{}, {}, {}, {}> -- mismatched index",
+        logger.trace( "skipping <obj {}, patch {} | obj {}, patch {}> -- mismatched index",
                       this_obj.id(), idx[0], idx[1], idx[2] );
         return;
       }
@@ -297,7 +297,7 @@ namespace bvh
       // Ignore self collisions (this will usually be caught by the above condition)
       if ( this_obj.get_impl().collision_idx == static_cast< std::size_t >( idx.y() ) )
       {
-        logger.trace( "skipping <{}, {}, {}, {}> -- self collision",
+        logger.trace( "skipping <obj {}, patch {} | obj {}, patch {}> -- self collision",
                       this_obj.id(), idx[0], idx[1], idx[2] );
         return;
       }
@@ -329,7 +329,7 @@ namespace bvh
         {
           auto lmsg = ::vt::makeMessage< result_msg >();
           lmsg->result = std::move( r.a );
-          logger.trace( "<send={}> result from <{}, {}, {}, {}>",
+          logger.trace( "<send={}> result from <obj {}, patch {} | obj {}, patch {}>",
                         left_node, this_obj.id(), idx[0], idx[1], idx[2] );
           this_obj.get_impl()
             .objgroup[left_node]
@@ -340,7 +340,7 @@ namespace bvh
         {
           auto rmsg = ::vt::makeMessage< result_msg >();
           rmsg->result = std::move( r.b );
-          logger.trace( "<send={}> result from <{}, {}, {}, {}>",
+          logger.trace( "<send={}> result from <obj {}, patch {} | obj {}, patch {}>",
                         right_node, this_obj.id(), idx[0], idx[1], idx[2] );
           this_obj.get_impl()
             .objgroup[right_node]
@@ -354,7 +354,7 @@ namespace bvh
       auto &this_obj = *_narrow->this_proxy.get()->self;
       auto &logger = this_obj.narrowphase_logger();
       const auto idx = _narrow->getIndex();
-      logger.trace( "clearing narrowphase index <{}, {}, {}, {}>",
+      logger.trace( "clearing narrowphase index <obj {}, patch {} | obj {}, patch {}>",
                     this_obj.id(), idx[0], idx[1], idx[2] );
       _narrow->active = false;
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -74,6 +74,18 @@ if (NOT BVH_DISABLE_TESTS)
     NAME "mpi_collision_object_multiple_broadphase_np_4"
     COMMAND mpirun -np 4 $<TARGET_FILE:BVHTests> "collision_object multiple broadphase")
   add_test(
+    NAME "mpi_collision_object_narrowphase_np_2"
+    COMMAND mpirun -np 2 $<TARGET_FILE:BVHTests> "collision_object narrowphase")
+  add_test(
+    NAME "mpi_collision_object_narrowphase_np_4"
+    COMMAND mpirun -np 4 $<TARGET_FILE:BVHTests> "collision_object narrowphase")
+  add_test(
+    NAME "mpi_collision_object_narrowphase_three_objects_np_2"
+    COMMAND mpirun -np 2 $<TARGET_FILE:BVHTests> "collision_object narrowphase three objects")
+  add_test(
+    NAME "mpi_collision_object_narrowphase_three_objects_np_4"
+    COMMAND mpirun -np 4 $<TARGET_FILE:BVHTests> "collision_object narrowphase three objects")
+  add_test(
     NAME "mpi_collision_object_narrowphase_multi_iteration_np_2"
     COMMAND mpirun -np 2 $<TARGET_FILE:BVHTests> "collision_object narrowphase multi-iteration")
   add_test(

--- a/tests/collision_object_test.cpp
+++ b/tests/collision_object_test.cpp
@@ -478,16 +478,16 @@ void verify_single_narrowphase_three_objects( const bvh::vt::reducable_vector< d
   }
 
   std::vector< collision_pair_t > expectedPairs;
-  for (int e0 = 0; e0 < numEltsOnObj0 * numNodes; e0++) {
-    for (int e1 = 0; e1 < numEltsOnObj1 * numNodes; e1++) {
+  for (std::size_t e0 = 0; e0 < numEltsOnObj0 * numNodes; e0++) {
+    for (std::size_t e1 = 0; e1 < numEltsOnObj1 * numNodes; e1++) {
       expectedPairs.push_back( { e0, 10 + e1 } );
     }
-    for (int e2 = 0; e2 < numEltsOnObj2 * numNodes; e2++) {
+    for (std::size_t e2 = 0; e2 < numEltsOnObj2 * numNodes; e2++) {
       expectedPairs.push_back( { e0, 20 + e2 } );
     }
   }
-  for (int e1 = 0; e1 < numEltsOnObj1 * numNodes; e1++) {
-    for (int e2 = 0; e2 < numEltsOnObj2 * numNodes; e2++) {
+  for (std::size_t e1 = 0; e1 < numEltsOnObj1 * numNodes; e1++) {
+    for (std::size_t e2 = 0; e2 < numEltsOnObj2 * numNodes; e2++) {
       expectedPairs.push_back( { 10 + e1, 20 + e2 } );
     }
   }

--- a/tests/collision_object_test.cpp
+++ b/tests/collision_object_test.cpp
@@ -364,7 +364,7 @@ void verify_single_narrowphase( const bvh::vt::reducable_vector< detailed_narrow
       res.patch_p, res.element_p, res.patch_q, res.element_q );
   }
 
-  std::size_t expectedNumCollisions = ( 1 * numNodes * 12 * numNodes ); // elts on obj 0 times elts on obj 1
+  std::size_t expectedNumCollisions = 1 * numNodes * 12 * numNodes;
   CHECK( results.size() == expectedNumCollisions );
 
   for ( std::size_t i = 0; i < std::min( results.size(), ref_rhs_element_ids.size() ); ++i )

--- a/tests/collision_object_test.cpp
+++ b/tests/collision_object_test.cpp
@@ -443,7 +443,7 @@ void verify_single_narrowphase_three_objects( const bvh::vt::reducable_vector< d
 {
   auto results = _res.vec;
 
-  bvh::vt::print("verify_single_narrowphase_new: found {} collision result(s).\n", results.size());
+  bvh::vt::debug("verify_single_narrowphase_new: found {} collision result(s).\n", results.size());
 
   // Expecting exactly 8 collisions:
   //   - single element of object 0 collides with element 0 and 1 of object 1 (2 collisions)
@@ -499,12 +499,12 @@ void verify_single_narrowphase_three_objects( const bvh::vt::reducable_vector< d
 
 TEST_CASE("collision_object narrowphase three objects", "[vt]") {
   std::cout << "starting my test\n";
-  bvh::collision_world world(2);
+  bvh::collision_world world(2); // power of 2
   auto &obj0 = world.create_collision_object();
   auto &obj1 = world.create_collision_object();
   auto &obj2 = world.create_collision_object();
 
-  auto split_method = bvh::split_algorithm::geom_axis;
+  auto split_method = GENERATE( bvh::split_algorithm::geom_axis, bvh::split_algorithm::ml_geom_axis);
 
   bvh::vt::reducable_vector< detailed_narrowphase_result > results;
 
@@ -524,21 +524,21 @@ TEST_CASE("collision_object narrowphase three objects", "[vt]") {
     obj2.set_entity_data(elements2, split_method);
     obj2.init_broadphase();
 
-    bvh::vt::print("Object 0 initialized with {} element(s):\n", elements0.extent(0));
+    bvh::vt::debug("Object 0 initialized with {} element(s):\n", elements0.extent(0));
     for (std::size_t i = 0; i < elements0.extent(0); i++) {
-      bvh::vt::print("  Element {}: global_id = {}\n", i, elements0(i).global_id());
+      bvh::vt::debug("  Element {}: global_id = {}\n", i, elements0(i).global_id());
       std::cout << elements0(i) << "\n";
     }
 
-    bvh::vt::print("Object 1 initialized with {} element(s):\n", elements1.extent(0));
+    bvh::vt::debug("Object 1 initialized with {} element(s):\n", elements1.extent(0));
     for (std::size_t i = 0; i < elements1.extent(0); i++) {
-      bvh::vt::print("  Element {}: global_id = {}\n", i, elements1(i).global_id());
+      bvh::vt::debug("  Element {}: global_id = {}\n", i, elements1(i).global_id());
       std::cout << elements1(i) << "\n";
     }
 
-    bvh::vt::print("Object 2 initialized with {} element(s):\n", elements2.extent(0));
+    bvh::vt::debug("Object 2 initialized with {} element(s):\n", elements2.extent(0));
     for (std::size_t i = 0; i < elements2.extent(0); i++) {
-      bvh::vt::print("  Element {}: global_id = {}\n", i, elements2(i).global_id());
+      bvh::vt::debug("  Element {}: global_id = {}\n", i, elements2(i).global_id());
       std::cout << elements2(i) << "\n";
     }
     CHECK(elements0.extent(0) == 1);

--- a/tests/collision_object_test.cpp
+++ b/tests/collision_object_test.cpp
@@ -344,7 +344,7 @@ bool operator<( const detailed_narrowphase_result &_lhs, const detailed_narrowph
 void verify_single_narrowphase( const bvh::vt::reducable_vector< detailed_narrowphase_result > &_res )
 {
   auto results = _res.vec;
-  auto numNodes = ::vt::theContext()->getNumNodes();
+  const auto numNodes = ::vt::theContext()->getNumNodes();
   std::vector< std::size_t > ref_rhs_element_ids( numNodes * 12 );
   std::iota( ref_rhs_element_ids.begin(), ref_rhs_element_ids.end(), 0UL );
 
@@ -364,7 +364,7 @@ void verify_single_narrowphase( const bvh::vt::reducable_vector< detailed_narrow
       res.patch_p, res.element_p, res.patch_q, res.element_q );
   }
 
-  std::size_t expectedNumCollisions = 1 * numNodes * 12 * numNodes;
+  const std::size_t expectedNumCollisions = 1 * numNodes * 12 * numNodes;
   CHECK( results.size() == expectedNumCollisions );
 
   for ( std::size_t i = 0; i < std::min( results.size(), ref_rhs_element_ids.size() ); ++i )
@@ -450,13 +450,13 @@ void verify_single_narrowphase_three_objects( const bvh::vt::reducable_vector< d
   auto numNodes = ::vt::theContext()->getNumNodes();
 
   // Define the problem
-  std::size_t numEltsOnObj0 = 1;
-  std::size_t numEltsOnObj1 = 2;
-  std::size_t numEltsOnObj2 = 2;
+  const std::size_t numEltsOnObj0 = 1;
+  const std::size_t numEltsOnObj1 = 2;
+  const std::size_t numEltsOnObj2 = 2;
 
   bvh::vt::debug( "verify_single_narrowphase_new: found {} collision result(s).\n", results.size() );
 
-  std::size_t expectedNumCollisions = (
+  const std::size_t expectedNumCollisions = (
     numEltsOnObj0 * numNodes * numEltsOnObj1 * numNodes + // obj 0 and obj 1
     numEltsOnObj0 * numNodes * numEltsOnObj2 * numNodes + // obj 0 and obj 2
     numEltsOnObj1 * numNodes * numEltsOnObj2 * numNodes   // obj 1 and obj 2
@@ -480,15 +480,15 @@ void verify_single_narrowphase_three_objects( const bvh::vt::reducable_vector< d
   std::vector< collision_pair_t > expectedPairs;
   for (std::size_t e0 = 0; e0 < numEltsOnObj0 * numNodes; e0++) {
     for (std::size_t e1 = 0; e1 < numEltsOnObj1 * numNodes; e1++) {
-      expectedPairs.push_back( { e0, 10 + e1 } );
+      expectedPairs.push_back( { e0, e1 } );
     }
     for (std::size_t e2 = 0; e2 < numEltsOnObj2 * numNodes; e2++) {
-      expectedPairs.push_back( { e0, 20 + e2 } );
+      expectedPairs.push_back( { e0, e2 } );
     }
   }
   for (std::size_t e1 = 0; e1 < numEltsOnObj1 * numNodes; e1++) {
     for (std::size_t e2 = 0; e2 < numEltsOnObj2 * numNodes; e2++) {
-      expectedPairs.push_back( { 10 + e1, 20 + e2 } );
+      expectedPairs.push_back( { e1, e2 } );
     }
   }
 
@@ -541,30 +541,27 @@ TEST_CASE( "collision_object narrowphase three objects", "[vt]" ) {
     obj0.set_entity_data( elements0, split_method );
     obj0.init_broadphase();
 
-    auto elements1 = build_element_grid( 1, 2, 1, 10 + (rank * 2), 0.0 );
+    auto elements1 = build_element_grid( 1, 2, 1, rank * 2, 0.0 );
     obj1.set_entity_data( elements1, split_method );
     obj1.init_broadphase();
 
-    auto elements2 = build_element_grid( 1, 1, 2, 20 + (rank * 2), 0.0 );
+    auto elements2 = build_element_grid( 1, 1, 2, rank * 2, 0.0 );
     obj2.set_entity_data( elements2, split_method );
     obj2.init_broadphase();
 
     bvh::vt::debug( "Object 0 initialized with {} element(s):\n", elements0.extent( 0 ) );
     for ( std::size_t i = 0; i < elements0.extent( 0 ); i++ ) {
       bvh::vt::debug( "  Element {}: global_id = {}\n", i, elements0( i ).global_id() );
-      std::cout << elements0( i ) << "\n";
     }
 
     bvh::vt::debug( "Object 1 initialized with {} element(s):\n", elements1.extent( 0 ) );
     for ( std::size_t i = 0; i < elements1.extent( 0 ); i++ ) {
       bvh::vt::debug( "  Element {}: global_id = {}\n", i, elements1( i ).global_id() );
-      std::cout << elements1( i ) << "\n";
     }
 
     bvh::vt::debug( "Object 2 initialized with {} element(s):\n", elements2.extent( 0 ) );
     for ( std::size_t i = 0; i < elements2.extent( 0 ); i++ ) {
       bvh::vt::debug( "  Element {}: global_id = {}\n", i, elements2( i ).global_id() );
-      std::cout << elements2( i ) << "\n";
     }
     CHECK( elements0.extent( 0 ) == 1 );
     CHECK( elements1.extent( 0 ) == 2 );
@@ -704,7 +701,6 @@ TEST_CASE( "collision_object narrowphase multi-iteration", "[vt]")
           REQUIRE( old_results.at( j ).idx == new_results.at( j ).idx );
       }
 
-      std::cout << "new results size " << new_results.size() << '\n';
       old_results = new_results;
 
       if ( i > 0 ) {
@@ -713,11 +709,9 @@ TEST_CASE( "collision_object narrowphase multi-iteration", "[vt]")
           REQUIRE( old_results2.at( j ).idx == new_results2.at( j ).idx );
       }
 
-      std::cout << "new results2 size " << new_results2.size() << '\n';
       old_results2 = new_results2;
     }
   } );
-  std::cout << "========== Done, ready for next gen!\n";
 }
 
 TEST_CASE( "collision_object narrowphase no overlap multi-iteration", "[vt]")
@@ -779,7 +773,6 @@ TEST_CASE( "collision_object narrowphase no overlap multi-iteration", "[vt]")
 
       std::vector< narrowphase_result > new_results2;
       obj2.for_each_result< narrowphase_result >( [&new_results2]( const narrowphase_result &_res ) {
-        std::cout << "got a result!!!\n";
         new_results2.emplace_back( _res );
       } );
 
@@ -791,7 +784,6 @@ TEST_CASE( "collision_object narrowphase no overlap multi-iteration", "[vt]")
           REQUIRE( old_results.at( j ).idx == new_results.at( j ).idx );
       }
 
-      std::cout << "new results size " << new_results.size() << '\n';
       old_results = new_results;
 
       if ( i > 0 ) {
@@ -800,7 +792,6 @@ TEST_CASE( "collision_object narrowphase no overlap multi-iteration", "[vt]")
           REQUIRE( old_results2.at( j ).idx == new_results2.at( j ).idx );
       }
 
-      std::cout << "new results2 size " << new_results2.size() << '\n';
       old_results2 = new_results2;
 
     }


### PR DESCRIPTION
Fixes: #43 

- [x] Add three objects collision test
- [x] Initialize third object and its elements
- [x] Adapt narrowphase result verification
- [x] Implement parallel testing 